### PR TITLE
fix: correct --overrides flag in AzDO publish pipeline template

### DIFF
--- a/src/templates/azure-devops/publish-pipeline.ts
+++ b/src/templates/azure-devops/publish-pipeline.ts
@@ -52,7 +52,7 @@ export function generatePublishPipeline(config: PublishPipelineConfig): string {
                       --resource-group $(APIM_RESOURCE_GROUP_${env.toUpperCase()}) \\
                       --service-name $(APIM_SERVICE_NAME_${env.toUpperCase()}) \\
                       --source ${config.artifactDir} \\
-                      --override configuration.${env}.yaml \\
+                      --overrides configuration.${env}.yaml \\
                       --commit-id $(Build.SourceVersion) \\
                       --subscription-id $(AZURE_SUBSCRIPTION_ID)
 
@@ -68,7 +68,7 @@ export function generatePublishPipeline(config: PublishPipelineConfig): string {
                       --resource-group $(APIM_RESOURCE_GROUP_${env.toUpperCase()}) \\
                       --service-name $(APIM_SERVICE_NAME_${env.toUpperCase()}) \\
                       --source ${config.artifactDir} \\
-                      --override configuration.${env}.yaml \\
+                      --overrides configuration.${env}.yaml \\
                       --subscription-id $(AZURE_SUBSCRIPTION_ID)
 `;
   }).join('\n');

--- a/tests/unit/templates/azure-devops/publish-pipeline.test.ts
+++ b/tests/unit/templates/azure-devops/publish-pipeline.test.ts
@@ -197,8 +197,8 @@ describe('azure-devops/publish-pipeline', () => {
         artifactDir: './apim-artifacts',
         environments: ['dev', 'prod'],
       });
-      expect(pipeline).toContain('--override configuration.dev.yaml');
-      expect(pipeline).toContain('--override configuration.prod.yaml');
+      expect(pipeline).toContain('--overrides configuration.dev.yaml');
+      expect(pipeline).toContain('--overrides configuration.prod.yaml');
     });
 
     it('should use npm ci to install dependencies (uses tgz from package.json)', () => {


### PR DESCRIPTION
The Azure DevOps publish pipeline generated by `apiops init` was passing `--override` (unrecognized by Commander.js) instead of `--overrides`, causing every pipeline run to fail with an unknown-option error — including runs with `publish-artifacts-in-last-commit` that should invoke incremental publish via `--commit-id $(Build.SourceVersion)`.

## Changes

- **`src/templates/azure-devops/publish-pipeline.ts`**: `--override` → `--overrides` in both the incremental and all-artifacts `AzureCLI@2` steps
- **`tests/unit/templates/azure-devops/publish-pipeline.test.ts`**: Updated assertion to match corrected flag

### Generated pipeline (incremental step)
```yaml
inlineScript: |
  npx apiops publish \
    --resource-group $(APIM_RESOURCE_GROUP_DEV) \
    --service-name $(APIM_SERVICE_NAME_DEV) \
    --source ./apim-artifacts \
    --overrides configuration.dev.yaml \   # was --override
    --commit-id $(Build.SourceVersion) \
    --subscription-id $(AZURE_SUBSCRIPTION_ID)
```

The conditional logic (`ne('${{ parameters.COMMIT_ID_CHOICE }}', 'publish-all-artifacts-in-repo')`) and `fetchDepth: 2` were already correct; only the flag name was wrong.