### PR TITLE
docs: add AADSTS700016 and UI access notes to integration-test skill

### DIFF
--- a/.github/skills/integration-test-prerequisites/SKILL.md
+++ b/.github/skills/integration-test-prerequisites/SKILL.md
@@ -159,7 +159,24 @@ gh api repos/${GITHUB_OWNER}/${GITHUB_REPO}/environments/${GITHUB_ENVIRONMENT}/s
 
 - `AADSTS70025`: Missing federated credential for presented subject.
 - `AADSTS700213`: Subject mismatch between token claim and federated credential.
+- `AADSTS700016`: Application/identity was deleted from the tenant. Recreate the UAMI and update secrets.
 - `Microsoft.Authorization/roleAssignments/write`: Missing `User Access Administrator` or `Owner`.
+
+## UI Access
+
+To view or edit environment secrets in the GitHub web UI, navigate to:
+
+```
+https://github.com/{GITHUB_OWNER}/{GITHUB_REPO}/settings/environments/{environment_id}/edit
+```
+
+The numeric `environment_id` can be retrieved via:
+
+```bash
+gh api repos/${GITHUB_OWNER}/${GITHUB_REPO}/environments --jq '.environments[] | select(.name=="'${GITHUB_ENVIRONMENT}'") | .id'
+```
+
+**Note:** Viewing environment settings requires **admin** access to the repository. In organizations using JIT (just-in-time) privilege elevation, you must activate admin access before the settings page will load (otherwise you get a 404).
 
 ## Anti-Patterns
 


### PR DESCRIPTION
Adds troubleshooting info to the integration-test-prerequisites skill:

- **AADSTS700016** failure mapping: identity deleted from tenant
- **UI Access** section: environment settings URL format (numeric ID required) and JIT admin access requirement

Based on debugging session where the managed identity had been deleted from the tenant.