### PR TITLE
fix: resolve cmd.exe quoting and stdin issues in Invoke-MaskedProcess

### DIFF
--- a/tests/integration/all-resource-types/modules/LogMasking.psm1
+++ b/tests/integration/all-resource-types/modules/LogMasking.psm1
@@ -261,20 +261,36 @@ function Invoke-MaskedProcess {
     )
 
     $exe = Resolve-NativeExecutable -Name $FilePath
-    $finalArgs = @() + $exe.Prefix + $Arguments
 
     $psi = [System.Diagnostics.ProcessStartInfo]::new()
     $psi.FileName               = $exe.FilePath
     $psi.RedirectStandardOutput = $true
     $psi.RedirectStandardError  = $true
-    $psi.RedirectStandardInput  = $false
+    $psi.RedirectStandardInput  = $true
     $psi.UseShellExecute        = $false
     $psi.CreateNoWindow         = $true
     $psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
     $psi.StandardErrorEncoding  = [System.Text.Encoding]::UTF8
 
-    foreach ($a in $finalArgs) {
-        [void]$psi.ArgumentList.Add([string]$a)
+    if ($exe.Prefix.Count -ge 2 -and $exe.Prefix[0] -eq '/c') {
+        # cmd.exe /c has special quoting rules that conflict with ArgumentList.
+        # Use the Arguments string property with double-quote wrapping so cmd.exe
+        # preserves the inner quotes around paths that contain spaces.
+        $cmdTarget = $exe.Prefix[1]
+        $quotedParts = @("`"$cmdTarget`"")
+        foreach ($a in $Arguments) {
+            $s = [string]$a
+            # Quote every argument individually so cmd.exe treats all content
+            # (including metacharacters like parentheses) as literals.
+            $escaped = $s -replace '"', '\"'
+            $quotedParts += "`"$escaped`""
+        }
+        $psi.Arguments = "/c `"$($quotedParts -join ' ')`""
+    } else {
+        $finalArgs = @() + $exe.Prefix + $Arguments
+        foreach ($a in $finalArgs) {
+            [void]$psi.ArgumentList.Add([string]$a)
+        }
     }
 
     $stdoutQueue = [System.Collections.Concurrent.ConcurrentQueue[string]]::new()
@@ -305,6 +321,7 @@ function Invoke-MaskedProcess {
 
     try {
         [void]$proc.Start()
+        $proc.StandardInput.Close()
 
         $outJob = Start-ThreadJob -ScriptBlock $readerScript -ArgumentList $proc.StandardOutput, $stdoutQueue
         $errJob = Start-ThreadJob -ScriptBlock $readerScript -ArgumentList $proc.StandardError,  $stderrQueue


### PR DESCRIPTION
## Summary

Fixes two Windows-specific bugs in `Invoke-MaskedProcess` (`LogMasking.psm1`) that caused integration test failures when the deploy scripts run `az` commands inside `Start-Job`.

## Changes

### 1. Stdin redirect hang fix
`RedirectStandardInput` was `$false`, so child processes spawned inside `Start-Job` (which has no parent console) inherited a broken stdin handle. Python (the `az` CLI runtime) hung on startup waiting for stdin initialization.

**Fix:** Set `RedirectStandardInput = $true` and close stdin immediately after `Start()`.

### 2. cmd.exe `/c` argument quoting fix
`ArgumentList` individually quotes each argument using C-runtime conventions, but `cmd.exe /c` has its own incompatible quoting rules:
- **Paths with spaces** (`C:\Program Files\...`) broke because `cmd.exe` stripped individual quotes and split at the space → `'C:\Program' is not recognized`
- **Metacharacters** like parentheses in JMESPath queries (e.g., `length(value[?name=='...'])`) were interpreted as cmd.exe grouping operators → `--output was unexpected at this time.`

**Fix:** For the `cmd.exe /c` case, use the `Arguments` string property instead of `ArgumentList`, with each argument individually quoted inside an outer `/c "..."` wrapper. This ensures cmd.exe passes all content through as literals.

## Testing
- Verified `az account show` works inside `Start-Job` (previously hung indefinitely)
- Verified arguments with spaces and parentheses pass through correctly
- Full roundtrip integration test passes through publish phase