### PR TITLE
Fully align filter and override config formats with APIOps Toolkit

### DIFF
--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -67,3 +67,53 @@ All new `.ts` files in `src/` and `tests/` must include:
 - [Microsoft Open Source Program](https://opensource.microsoft.com/program)
 
 ---
+
+### 2026-07-16: Issue #114 Architectural Review — Filter & Override Toolkit Alignment
+**By:** ApiOpsLead  
+**Status:** Approved (Follow-up required)  
+**What:** Architecture review of issue #114 models, config loader, filter service, override merger, workspace extractor, transitive resolver.
+
+**Key Findings:**
+
+- **OverrideEntry recursive model:** Sound design, well-bounded recursion (max depth 3), no cycle risk.
+- **Toolkit parity:** All 14 override sections and 16 filter fields implemented. `Workspace` filter added correctly.
+- **Forward compatibility (§VII):** Clean extension points; 1–3 LOC cost per new section/relationship.
+- **Override merger traversal:** 🟡 ApiOperationPolicy double-nesting gap — YAML is 3-level (`apis → operations → policies`), but `applyNestedOverride` does 2-level traversal only. Practical impact low (rare use, operation properties typically empty).
+- **Filter service sub-filtering:** ✅ Correct semantics (case-insensitive matching, proper empty array handling).
+- **Workspace sub-filter consumption:** ✅ Parsed correctly, consumption path can follow in separate PR.
+
+**Verdict:** Approve. Architecture maps cleanly to Toolkit format with sound design and good extension points. ApiOperationPolicy gap is non-blocking — **file follow-up issue.**
+
+**Constitution compliance:** §II (APIM Native), §V (YAGNI), §VI (Testability), §VII (Forward Compatibility)
+
+---
+
+### 2026-07-16: Issue #114 Code Review — Standards & Testability
+**By:** CodeReviewer  
+**Status:** Request Changes (5 required items)  
+**What:** Standards review of 6 source files, 3 test files, 4 doc/template files for issue #114.
+
+**Required Changes (🟡):**
+
+| ID | Issue | File(s) | Principle |
+|----|-------|---------|-----------|
+| R1 | ApiOperationPolicy nested override lookup broken | override-merger.ts | §IV Idempotent Operations |
+| R2 | Filter name case sensitivity doc/code mismatch | filtering-resources.md | §III Configuration as Code |
+| R3 | Duplicate override names silently overwritten | config-loader.ts | §I CLI-First Design |
+| R4 | Workspace sub-filters parsed but never consumed | config.ts, config-loader.ts, workspace-extractor.ts | §V Simplicity/YAGNI |
+| R5 | Zero test coverage for nested override functionality | override-merger.test.ts, config-loader.test.ts | §VI Testability by Design |
+
+**Details:**
+- **R1:** Remove `ApiOperationPolicy` from `CHILD_OVERRIDE_MAP` or implement multi-level traversal for 3-deep nesting.
+- **R2:** `matchesFilter()` uses `.toLowerCase()` (case-insensitive); update docs from "case-sensitive" to "case-insensitive."
+- **R3:** Emit warning when duplicate `name` in override array; currently silently overwrites.
+- **R4:** Either remove workspace sub-filter parsing/model or implement consumption in filter-service/workspace-extractor.
+- **R5:** Add tests: ApiDiagnostic nested override, ApiOperation nested override, ProductPolicy nested override, config loader nested override parsing, config loader API sub-filter parsing, config loader workspace sub-filter parsing (if kept).
+
+**Positive Observations:** All 9 files have correct copyright headers. Zero `any` types. All imports use `.js` extensions. Forward compatibility preserved (§VII). Immutability maintained. Secret safety compliant (§VIII). Error handling is actionable. Idempotent design verified (§IV). Legacy alias support with deprecation warnings. Template quality high.
+
+**Verdict:** Well-structured implementation with good constitution compliance. R1–R5 must be resolved before merge. No blockers.
+
+**Constitution compliance:** §I, §III, §IV, §V, §VI, §VII, §VIII
+
+---

--- a/docs/ci-cd/azure-devops.md
+++ b/docs/ci-cd/azure-devops.md
@@ -43,7 +43,7 @@ The extract pipeline pulls configuration from your APIM instance, publishes the 
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `CONFIGURATION_YAML_PATH` | string | `Extract All APIs` | Choose `Extract All APIs` for a full extract, or `configuration.extract.yaml` to use a [filter file](../guides/filtering-resources.md) |
+| `CONFIGURATION_YAML_PATH` | string | `Extract All APIs` | Choose `Extract All APIs` for a full extract, or `configuration.extractor.yaml` to use a [filter file](../guides/filtering-resources.md) |
 | `resourceGroup` | string | `$(APIM_RESOURCE_GROUP)` | Azure resource group containing your APIM instance |
 | `serviceName` | string | `$(APIM_SERVICE_NAME)` | Name of the APIM service instance |
 
@@ -55,7 +55,7 @@ flowchart TD
     B --> C[npm ci]
     C --> D{Configuration choice?}
     D -->|Extract All APIs| E[apiops extract --resource-group ... --service-name ...]
-    D -->|configuration.extract.yaml| F[apiops extract ... --filter configuration.extract.yaml]
+    D -->|configuration.extractor.yaml| F[apiops extract ... --filter configuration.extractor.yaml]
     E --> G[Publish pipeline artifact]
     F --> G
     G --> H[Create branch apim-extract-BuildId]
@@ -92,7 +92,7 @@ The key task is `AzureCLI@2`, which authenticates using your service connection:
         --subscription-id $(AZURE_SUBSCRIPTION_ID)
 ```
 
-When the filter option is selected, `--filter configuration.extract.yaml` is added to the command.
+When the filter option is selected, `--filter configuration.extractor.yaml` is added to the command.
 
 > **Why AzureCLI@2?** This task injects Azure credentials into the shell environment, allowing `apiops extract` to authenticate via `DefaultAzureCredential`. See [Authentication Guide](../guides/authentication.md).
 

--- a/docs/ci-cd/github-actions.md
+++ b/docs/ci-cd/github-actions.md
@@ -44,7 +44,7 @@ The extract workflow pulls configuration from your APIM instance and creates a P
 | Input | Description | Options |
 |-------|-------------|---------|
 | `ENVIRONMENT` | Which APIM instance to extract from | `dev`, `prod` |
-| `CONFIGURATION_YAML_PATH` | Extract all APIs or use a filter file | `Extract All APIs`, `configuration.extract.yaml` |
+| `CONFIGURATION_YAML_PATH` | Extract all APIs or use a filter file | `Extract All APIs`, `configuration.extractor.yaml` |
 
 ### What It Does
 

--- a/docs/commands/extract.md
+++ b/docs/commands/extract.md
@@ -34,7 +34,7 @@ apiops extract \
   --subscription-id 00000000-0000-0000-0000-000000000000 \
   --resource-group my-rg \
   --service-name my-apim \
-  --filter ./configuration.extract.yaml
+  --filter ./configuration.extractor.yaml
 ```
 
 ### Extract without transitive dependencies
@@ -98,23 +98,23 @@ By default, `apiops extract` exports **all** resources from the APIM instance (3
 To extract only specific resources, pass a YAML filter file with `--filter`:
 
 ```yaml
-# configuration.extract.yaml
-apiNames:
+# configuration.extractor.yaml
+apis:
   - echo-api
   - petstore-api
-productNames:
+products:
   - starter
-backendNames:
+backends:
   - backend-api
-namedValueNames:
+namedValues:
   - api-key
-tagNames:
+tags:
   - production
-policyFragmentNames:
+policyFragments:
   - rate-limit-fragment
-loggerNames:
+loggers:
   - appinsights-logger
-diagnosticNames:
+diagnostics:
   - applicationinsights
 ```
 
@@ -124,22 +124,22 @@ All 16 supported filter keys:
 
 | Filter key | Resource type |
 |------------|---------------|
-| `apiNames` | APIs |
-| `backendNames` | Backends |
-| `productNames` | Products |
-| `namedValueNames` | Named values |
-| `loggerNames` | Loggers |
-| `diagnosticNames` | Diagnostics |
-| `tagNames` | Tags |
-| `policyFragmentNames` | Policy fragments |
-| `gatewayNames` | Gateways |
-| `versionSetNames` | API version sets |
-| `groupNames` | Groups |
-| `subscriptionNames` | Subscriptions |
-| `schemaNames` | Schemas |
-| `policyRestrictionNames` | Policy restrictions |
-| `documentationNames` | Documentation resources |
-| `workspaceNames` | Workspaces |
+| `apis` | APIs |
+| `backends` | Backends |
+| `products` | Products |
+| `namedValues` | Named values |
+| `loggers` | Loggers |
+| `diagnostics` | Diagnostics |
+| `tags` | Tags |
+| `policyFragments` | Policy fragments |
+| `gateways` | Gateways |
+| `versionSets` | API version sets |
+| `groups` | Groups |
+| `subscriptions` | Subscriptions |
+| `schemas` | Schemas |
+| `policyRestrictions` | Policy restrictions |
+| `documentations` | Documentation resources |
+| `workspaces` | Workspaces |
 
 ### Transitive dependencies
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -80,7 +80,7 @@ In interactive mode (the default when running in a terminal), `apiops init` prom
 |------|---------|
 | `.github/workflows/extract.yaml` | Pipeline to extract APIM artifacts |
 | `.github/workflows/publish.yaml` | Pipeline to publish artifacts to APIM |
-| `configuration.extract.yaml` | Sample filter configuration for extraction |
+| `configuration.extractor.yaml` | Sample filter configuration for extraction |
 | `configuration.{env}.yaml` | Override templates per environment (e.g., `configuration.dev.yaml`, `configuration.prod.yaml`) |
 | `IDENTITY-SETUP-GITHUB.md` | Step-by-step guide for configuring federated credentials |
 
@@ -90,9 +90,7 @@ In interactive mode (the default when running in a terminal), `apiops init` prom
 |------|---------|
 | `pipelines/extract.yaml` | Pipeline to extract APIM artifacts |
 | `pipelines/publish.yaml` | Pipeline to publish artifacts to APIM |
-| `configuration.extract.yaml` | Sample filter configuration for extraction |
-| `configuration.{env}.yaml` | Override templates per environment |
-| `IDENTITY-SETUP-AZDO.md` | Step-by-step guide for configuring service connections |
+| `configuration.extractor.yaml` | Sample filter configuration for extraction |
 
 ### Both platforms
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -78,8 +78,8 @@ In interactive mode (the default when running in a terminal), `apiops init` prom
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/extract.yaml` | Pipeline to extract APIM artifacts |
-| `.github/workflows/publish.yaml` | Pipeline to publish artifacts to APIM |
+| `.github/workflows/run-apim-extractor.yml` | Workflow to extract APIM artifacts |
+| `.github/workflows/run-apim-publisher.yml` | Workflow to publish artifacts to APIM |
 | `configuration.extractor.yaml` | Sample filter configuration for extraction |
 | `configuration.{env}.yaml` | Override templates per environment (e.g., `configuration.dev.yaml`, `configuration.prod.yaml`) |
 | `IDENTITY-SETUP-GITHUB.md` | Step-by-step guide for configuring federated credentials |
@@ -88,8 +88,8 @@ In interactive mode (the default when running in a terminal), `apiops init` prom
 
 | File | Purpose |
 |------|---------|
-| `pipelines/extract.yaml` | Pipeline to extract APIM artifacts |
-| `pipelines/publish.yaml` | Pipeline to publish artifacts to APIM |
+| `.azdo/pipelines/run-apim-extractor.yml` | Pipeline to extract APIM artifacts |
+| `.azdo/pipelines/run-apim-publisher.yml` | Pipeline to publish artifacts to APIM |
 | `configuration.extractor.yaml` | Sample filter configuration for extraction |
 | `configuration.{env}.yaml` | Override templates per environment |
 | `IDENTITY-SETUP-AZDO.md` | Step-by-step guide for configuring service connections |
@@ -98,6 +98,7 @@ In interactive mode (the default when running in a terminal), `apiops init` prom
 
 | File | Purpose |
 |------|---------|
+| `.github/prompts/apiops-setup-identity.prompt.md` | Copilot prompt for identity setup |
 | `<artifact-dir>/` | Empty artifact directory (default: `./apim-artifacts`) |
 
 ## Package consumption modes

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -91,6 +91,8 @@ In interactive mode (the default when running in a terminal), `apiops init` prom
 | `pipelines/extract.yaml` | Pipeline to extract APIM artifacts |
 | `pipelines/publish.yaml` | Pipeline to publish artifacts to APIM |
 | `configuration.extractor.yaml` | Sample filter configuration for extraction |
+| `configuration.{env}.yaml` | Override templates per environment |
+| `IDENTITY-SETUP-AZDO.md` | Step-by-step guide for configuring service connections |
 
 ### Both platforms
 

--- a/docs/guides/environment-overrides.md
+++ b/docs/guides/environment-overrides.md
@@ -27,8 +27,7 @@ apiops publish \
 
 `apiops-cli` uses the [APIOps Toolkit](https://github.com/Azure/apiops) override layout:
 
-- Top-level resource sections: `namedValues`, `backends`, `apis`, `diagnostics`, `loggers`
-  > **Note:** Gateway and subscription overrides are not currently supported.
+- Top-level resource sections: `namedValues`, `backends`, `apis`, `diagnostics`, `loggers`, `policies`, `gateways`, `versionSets`, `groups`, `subscriptions`, `products`, `tags`, `policyFragments`, `workspaces`
 - Each section is a list
 - Each list item contains `name` and `properties`
 
@@ -53,6 +52,14 @@ apis:
   - name: petstore-api
     properties:
       serviceUrl: "https://petstore.contoso.com/v1"
+    diagnostics:
+      - name: applicationinsights
+        properties:
+          loggerId: "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.ApiManagement/service/<apim>/loggers/prod-appinsights"
+    policies:
+      - name: policy
+        properties:
+          format: rawxml
 
 diagnostics:
   - name: applicationinsights
@@ -65,9 +72,46 @@ loggers:
       resourceId: "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/microsoft.insights/components/prod-appinsights"
       credentials:
         instrumentationKey: "prod-key"
+
+# Additional override sections (all APIOps Toolkit sections are supported):
+# policies:
+#   - name: policy
+#     properties:
+#       format: rawxml
+# gateways:
+#   - name: my-gateway
+#     properties:
+#       locationData:
+#         name: "gateway location"
+# versionSets:
+#   - name: my-version-set
+#     properties:
+#       displayName: "My Version Set"
+# groups:
+#   - name: my-group
+#     properties:
+#       displayName: "My Group"
+# subscriptions:
+#   - name: my-subscription
+#     properties:
+#       displayName: "My Subscription"
+# products:
+#   - name: my-product
+#     properties:
+#       displayName: "My Product"
+# tags:
+#   - name: my-tag
+#     properties:
+#       displayName: "My Tag"
+# policyFragments:
+#   - name: my-fragment
+#     properties:
+#       description: "My Policy Fragment"
 ```
 
 ## Override capabilities by resource type
+
+Override properties are generic — any ARM resource property can be overridden. The examples below show common use cases per resource type, but you're not limited to these properties.
 
 ### Named values
 
@@ -83,14 +127,6 @@ namedValues:
         identityClientId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 ```
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `value` | `string` | Plain-text value |
-| `displayName` | `string` | Display name in the portal |
-| `tags` | `string[]` | Resource tags |
-| `keyVault.secretIdentifier` | `string` | Key Vault secret URI |
-| `keyVault.identityClientId` | `string` | Managed identity client ID for Key Vault access |
-
 ### Backends
 
 ```yaml
@@ -98,16 +134,12 @@ backends:
   - name: petstore-backend
     properties:
       url: "https://petstore-prod.contoso.com"
+      resourceId: "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Web/sites/prod-backend"
       credentials:
         header:
           x-api-key:
             - "prod-backend-key"
 ```
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `url` | `string` | Backend service URL |
-| `credentials` | `object` | Authentication credentials (headers, query params, certificates) |
 
 ### APIs
 
@@ -116,24 +148,48 @@ apis:
   - name: petstore-api
     properties:
       serviceUrl: "https://petstore-prod.contoso.com/v1"
+      displayName: "Petstore API (Production)"
 ```
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `serviceUrl` | `string` | Backend service URL for the API |
+### APIs with nested sub-resource overrides
 
-### Diagnostics
+API entries support nested sub-resource overrides for diagnostics, operations, policies, and releases:
+
+```yaml
+apis:
+  - name: petstore-api
+    properties:
+      serviceUrl: "https://petstore-prod.contoso.com/v1"
+    diagnostics:
+      - name: applicationinsights
+        properties:
+          loggerId: "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.ApiManagement/service/<apim>/loggers/prod-appinsights"
+          verbosity: Error
+    operations:
+      - name: get-pets
+        policies:
+          - name: policy
+            properties:
+              format: rawxml
+    policies:
+      - name: policy
+        properties:
+          format: rawxml
+    releases:
+      - name: v1-release
+        properties:
+          notes: "Production release"
+```
+
+### Diagnostics (service-level)
 
 ```yaml
 diagnostics:
   - name: applicationinsights
     properties:
       loggerId: "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.ApiManagement/service/<apim>/loggers/prod-appinsights"
+      verbosity: Error
 ```
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `loggerId` | `string` | Full resource ID of the target logger |
 
 ### Loggers
 
@@ -141,15 +197,38 @@ diagnostics:
 loggers:
   - name: appinsights-logger
     properties:
+      loggerType: applicationInsights
       resourceId: "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/microsoft.insights/components/prod-appinsights"
       credentials:
         instrumentationKey: "prod-instrumentation-key"
+      isBuffered: true
 ```
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `resourceId` | `string` | Azure resource ID of the logging target (for example, Application Insights) |
-| `credentials` | `object` | Credentials for the logging service |
+### Service-level policies
+
+```yaml
+policies:
+  - name: policy
+    properties:
+      format: rawxml
+```
+
+### All other resource types
+
+Overrides are also supported for: `gateways`, `versionSets`, `groups`, `subscriptions`, `products`, `tags`, `policyFragments`, and `workspaces`. Each uses the same `name` + `properties` format:
+
+```yaml
+gateways:
+  - name: on-prem-gateway
+    properties:
+      locationData:
+        name: "On-premises datacenter"
+
+products:
+  - name: starter-product
+    properties:
+      displayName: "Starter (Production)"
+```
 
 ## Override rules
 

--- a/docs/guides/filtering-resources.md
+++ b/docs/guides/filtering-resources.md
@@ -104,7 +104,9 @@ apis:
 
 ### Workspace sub-resource filters
 
-For workspaces, you can specify which workspace-scoped resources to extract:
+> **Note:** Workspace sub-resource filtering is parsed but not yet applied at runtime. Currently, including a workspace extracts all resources within it. This matches the Toolkit's configuration format for forward compatibility. See [#119](https://github.com/Azure/apiops-cli/issues/119) for tracking.
+
+The configuration format supports specifying which workspace-scoped resources to extract:
 
 ```yaml
 workspaces:
@@ -140,6 +142,7 @@ Supported workspace sub-filter keys: `apis`, `backends`, `diagnostics`, `groups`
 | `groups` | Groups | `developers`, `partners`, `admins` |
 | `subscriptions` | Subscriptions | `team-a-subscription` |
 | `schemas` | Global Schemas | `shared-error-schema` |
+| `policies` | Service-level Policies | `policy` |
 | `policyRestrictions` | Policy Restrictions | `no-external-calls` |
 | `documentations` | Documentation | `getting-started`, `changelog` |
 | `workspaces` | Workspaces | `team-a-workspace`, `team-b-workspace` |

--- a/docs/guides/filtering-resources.md
+++ b/docs/guides/filtering-resources.md
@@ -16,8 +16,8 @@ By default, `apiops extract` pulls every resource from your APIM instance. For l
 1. Create a filter file:
 
 ```yaml
-# configuration.extract.yaml
-apiNames:
+# configuration.extractor.yaml
+apis:
   - petstore-api
   - orders-api
 ```
@@ -29,7 +29,7 @@ apiops extract \
   --resource-group my-rg \
   --service-name my-apim \
   --subscription-id 00000000-0000-0000-0000-000000000000 \
-  --filter configuration.extract.yaml
+  --filter configuration.extractor.yaml
 ```
 
 Only `petstore-api`, `orders-api`, and their transitive dependencies are extracted.
@@ -41,29 +41,29 @@ Only `petstore-api`, `orders-api`, and their transitive dependencies are extract
 The filter file is a YAML document where each key is a resource type and the value is an array of resource names:
 
 ```yaml
-# configuration.extract.yaml
+# configuration.extractor.yaml
 
 # APIs to extract (by display name or API ID)
-apiNames:
+apis:
   - petstore-api
   - orders-api
 
 # Backends to include
-backendNames:
+backends:
   - orders-backend
 
 # Products to include
-productNames:
+products:
   - starter
   - enterprise
 
 # Named values to include
-namedValueNames:
+namedValues:
   - api-key
   - connection-string
 
 # Leave sections out (or comment them) to extract ALL of that type
-# loggerNames:
+# loggers:
 #   - appinsights
 ```
 
@@ -79,22 +79,22 @@ namedValueNames:
 
 | Filter Field | APIM Resource | Example Values |
 |-------------|---------------|----------------|
-| `apiNames` | APIs | `petstore-api`, `orders-v2` |
-| `backendNames` | Backends | `orders-backend`, `payment-service` |
-| `productNames` | Products | `starter`, `enterprise`, `internal` |
-| `namedValueNames` | Named Values | `api-key`, `db-connection-string` |
-| `loggerNames` | Loggers | `appinsights-logger`, `eventhub-logger` |
-| `diagnosticNames` | Diagnostics | `applicationinsights`, `azuremonitor` |
-| `tagNames` | Tags | `production`, `beta`, `internal` |
-| `policyFragmentNames` | Policy Fragments | `rate-limit-fragment`, `cors-policy` |
-| `gatewayNames` | Self-hosted Gateways | `on-prem-gateway`, `edge-gateway` |
-| `versionSetNames` | API Version Sets | `orders-version-set` |
-| `groupNames` | Groups | `developers`, `partners`, `admins` |
-| `subscriptionNames` | Subscriptions | `team-a-subscription` |
-| `schemaNames` | Global Schemas | `shared-error-schema` |
-| `policyRestrictionNames` | Policy Restrictions | `no-external-calls` |
-| `documentationNames` | Documentation | `getting-started`, `changelog` |
-| `workspaceNames` | Workspaces | `team-a-workspace`, `team-b-workspace` |
+| `apis` | APIs | `petstore-api`, `orders-v2` |
+| `backends` | Backends | `orders-backend`, `payment-service` |
+| `products` | Products | `starter`, `enterprise`, `internal` |
+| `namedValues` | Named Values | `api-key`, `db-connection-string` |
+| `loggers` | Loggers | `appinsights-logger`, `eventhub-logger` |
+| `diagnostics` | Diagnostics | `applicationinsights`, `azuremonitor` |
+| `tags` | Tags | `production`, `beta`, `internal` |
+| `policyFragments` | Policy Fragments | `rate-limit-fragment`, `cors-policy` |
+| `gateways` | Self-hosted Gateways | `on-prem-gateway`, `edge-gateway` |
+| `versionSets` | API Version Sets | `orders-version-set` |
+| `groups` | Groups | `developers`, `partners`, `admins` |
+| `subscriptions` | Subscriptions | `team-a-subscription` |
+| `schemas` | Global Schemas | `shared-error-schema` |
+| `policyRestrictions` | Policy Restrictions | `no-external-calls` |
+| `documentations` | Documentation | `getting-started`, `changelog` |
+| `workspaces` | Workspaces | `team-a-workspace`, `team-b-workspace` |
 
 ---
 
@@ -120,7 +120,7 @@ flowchart TD
 Given this filter:
 
 ```yaml
-apiNames:
+apis:
   - petstore-api
 ```
 
@@ -150,7 +150,7 @@ apiops extract \
   --resource-group my-rg \
   --service-name my-apim \
   --subscription-id 00000000-0000-0000-0000-000000000000 \
-  --filter configuration.extract.yaml \
+  --filter configuration.extractor.yaml \
   --no-transitive
 ```
 
@@ -170,8 +170,8 @@ apiops extract \
 A team that owns one or two APIs:
 
 ```yaml
-# configuration.extract.yaml
-apiNames:
+# configuration.extractor.yaml
+apis:
   - orders-api
   - orders-admin-api
 ```
@@ -183,33 +183,33 @@ Transitive dependencies (backends, named values, policy fragments) are auto-incl
 Extract everything associated with a product:
 
 ```yaml
-# configuration.extract.yaml
-productNames:
+# configuration.extractor.yaml
+products:
   - enterprise
 ```
 
-> **Note:** Filtering by `productNames` extracts the product definition and its associations, but does **not** transitively include the APIs in that product. To include the APIs, add them to `apiNames` as well.
+> **Note:** Filtering by `products` extracts the product definition and its associations, but does **not** transitively include the APIs in that product. To include the APIs, add them to `apis` as well.
 
 ### Shared Infrastructure Team
 
 A platform team managing cross-cutting resources:
 
 ```yaml
-# configuration.extract.yaml
-namedValueNames:
+# configuration.extractor.yaml
+namedValues:
   - global-api-key
   - rate-limit-threshold
   - cors-allowed-origins
 
-policyFragmentNames:
+policyFragments:
   - standard-rate-limit
   - cors-policy
   - auth-validation
 
-loggerNames:
+loggers:
   - appinsights-logger
 
-backendNames:
+backends:
   - identity-service
 ```
 
@@ -222,7 +222,7 @@ There is no "exclude" syntax. To extract everything except certain resources, li
 ## Tips
 
 - **Start broad, narrow later** — Begin with no filter to see what's in your APIM instance, then create a filter for your team's slice
-- **One filter per team** — In multi-team setups, each team maintains its own `configuration.extract.yaml`
+- **One filter per team** — In multi-team setups, each team maintains its own `configuration.extractor.yaml`
 - **Commit the filter file** — Keep it in version control alongside your artifacts so CI/CD pipelines can use it
 - **Case-sensitive names** — Filter values must match APIM resource names exactly (usually lowercase with hyphens)
 - **Validate early** — The config loader validates that each filter field is an array of strings and will throw `Failed to load filter config` on invalid YAML

--- a/docs/guides/filtering-resources.md
+++ b/docs/guides/filtering-resources.md
@@ -69,9 +69,57 @@ namedValues:
 
 **Rules:**
 - Each field is optional — omit it to extract all resources of that type
-- Each field must be an array of strings (validated at load time)
-- Names are case-sensitive and must match the APIM resource name exactly
+- Simple fields must be an array of strings
+- `apis` and `workspaces` also accept nested object entries for sub-resource filtering (see below)
+- Names are matched case-insensitively against APIM resource names
 - An empty file extracts everything (same as no filter)
+- An empty array (`[]`) excludes ALL resources of that type
+
+---
+
+## Nested Sub-Resource Filtering
+
+### API sub-resource filters
+
+For APIs, you can control which sub-resources (operations, diagnostics, schemas, releases) are extracted. Use an object entry instead of a plain string:
+
+```yaml
+apis:
+  - petstore-api                  # Simple: include all sub-resources
+  - orders-api:                   # Nested: control sub-resources
+      operations:
+        - get-order
+        - create-order
+      diagnostics:
+        - applicationinsights
+      schemas: []                 # Empty = exclude ALL schemas
+      releases:
+        - v1-release
+```
+
+**Sub-filter rules:**
+- If a sub-resource key is **omitted**, all sub-resources of that type are included
+- If a sub-resource key is an **empty array** (`[]`), all sub-resources of that type are excluded
+- If a sub-resource key lists **names**, only those sub-resources are included
+
+### Workspace sub-resource filters
+
+For workspaces, you can specify which workspace-scoped resources to extract:
+
+```yaml
+workspaces:
+  - team-a-workspace:             # Nested: control workspace resources
+      apis:
+        - team-api-1
+        - team-api-2
+      backends:
+        - team-backend
+      namedValues:
+        - team-api-key
+  - team-b-workspace              # Simple: extract all resources
+```
+
+Supported workspace sub-filter keys: `apis`, `backends`, `diagnostics`, `groups`, `loggers`, `namedValues`, `policyFragments`, `products`, `subscriptions`, `tags`, `versionSets`.
 
 ---
 
@@ -224,8 +272,8 @@ There is no "exclude" syntax. To extract everything except certain resources, li
 - **Start broad, narrow later** — Begin with no filter to see what's in your APIM instance, then create a filter for your team's slice
 - **One filter per team** — In multi-team setups, each team maintains its own `configuration.extractor.yaml`
 - **Commit the filter file** — Keep it in version control alongside your artifacts so CI/CD pipelines can use it
-- **Case-sensitive names** — Filter values must match APIM resource names exactly (usually lowercase with hyphens)
-- **Validate early** — The config loader validates that each filter field is an array of strings and will throw `Failed to load filter config` on invalid YAML
+- **Case-insensitive matching** — Filter values are matched case-insensitively against APIM resource names
+- **Validate early** — The config loader validates filter entries and will throw `Failed to load filter config` on invalid YAML. Unknown top-level keys produce a warning.
 
 ---
 

--- a/docs/guides/migration-from-v1.md
+++ b/docs/guides/migration-from-v1.md
@@ -1,23 +1,23 @@
-# Migration from v1 Toolkit
+# Migration from APIOps Toolkit
 
-Migrate from the [Azure/apiops](https://github.com/Azure/apiops) toolkit (v1) to apiops-cli (v2) — same concepts, simpler tooling, more features.
+Migrate from the [APIOps Toolkit](https://github.com/Azure/apiops) to apiops-cli — same concepts, simpler tooling, more features.
 
 ## Why Migrate?
 
-The v1 toolkit uses separate Extractor and Publisher binaries orchestrated by pipeline templates. It works, but:
+The APIOps Toolkit uses separate Extractor and Publisher binaries orchestrated by pipeline templates. It works, but:
 
 - Requires Docker or the .NET SDK to run
 - Uses two separate configuration files and complex pipeline YAML
 - Supports ~20 resource types
 - Has no built-in dry-run, incremental publish, or scaffolding command
 
-apiops-cli (v2) is a single Node.js CLI that covers the full workflow with less setup.
+apiops-cli is a single Node.js CLI that covers the full workflow with less setup.
 
 ---
 
 ## Key Differences
 
-| Feature | v1 (Azure/apiops) | v2 (apiops-cli) |
+| Feature | APIOps Toolkit | apiops-cli |
 |---------|-------------------|-----------------|
 | **Runtime** | .NET SDK or Docker | Node.js 22+ |
 | **CLI** | Separate Extractor/Publisher binaries | Single `apiops` CLI |
@@ -33,9 +33,9 @@ apiops-cli (v2) is a single Node.js CLI that covers the full workflow with less 
 | **Resource types** | ~20 | 34 (see below) |
 | **Pipeline targets** | GitHub Actions, Azure DevOps | GitHub Actions, Azure DevOps |
 
-### Additional resource types in v2
+### Additional resource types in apiops-cli
 
-v2 supports all v1 resource types plus: `GlobalSchema`, `PolicyRestriction`, `Documentation`, `ApiSchema`, `ApiRelease`, `ApiTagDescription`, `ApiWiki`, `ProductWiki`, `GraphQLResolver`, `McpServer`, and more.
+apiops-cli supports all APIOps Toolkit resource types plus: `GlobalSchema`, `PolicyRestriction`, `Documentation`, `ApiSchema`, `ApiRelease`, `ApiTagDescription`, `ApiWiki`, `ProductWiki`, `GraphQLResolver`, `McpServer`, and more.
 
 ---
 
@@ -70,7 +70,7 @@ This creates:
 
 ### 3. Verify artifact compatibility
 
-**Your existing extracted artifacts should work as-is with v2.** The artifact format is backward compatible — v2 reads the same `apiInformation.json`, `backendInformation.json`, `policy.xml`, and other files that v1 produces.
+**Your existing extracted artifacts should work as-is with apiops-cli.** The artifact format is backward compatible — apiops-cli reads the same `apiInformation.json`, `backendInformation.json`, `policy.xml`, and other files that the APIOps Toolkit produces.
 
 Test by running a dry-run against your existing artifacts:
 
@@ -86,11 +86,11 @@ If the dry-run shows the expected resources, your artifacts are compatible.
 
 ### 4. Update pipeline YAML
 
-Replace the v1 pipeline tasks/actions with v2 CLI commands.
+Replace the APIOps Toolkit pipeline tasks/actions with apiops-cli commands.
 
 #### GitHub Actions
 
-**v1 (before):**
+**APIOps Toolkit (before):**
 
 ```yaml
 - name: Run Publisher
@@ -102,7 +102,7 @@ Replace the v1 pipeline tasks/actions with v2 CLI commands.
     CONFIGURATION_YAML_PATH: configuration.publisher.yaml
 ```
 
-**v2 (after):**
+**apiops-cli (after):**
 
 ```yaml
 - name: Publish APIs
@@ -116,7 +116,7 @@ Replace the v1 pipeline tasks/actions with v2 CLI commands.
 
 #### Azure DevOps
 
-**v1 (before):**
+**APIOps Toolkit (before):**
 
 ```yaml
 - task: AzureCLI@2
@@ -126,7 +126,7 @@ Replace the v1 pipeline tasks/actions with v2 CLI commands.
         --configuration-yaml-path configuration.publisher.yaml
 ```
 
-**v2 (after):**
+**apiops-cli (after):**
 
 ```yaml
 - task: AzureCLI@2
@@ -145,7 +145,7 @@ Replace the v1 pipeline tasks/actions with v2 CLI commands.
 
 #### Extractor configuration
 
-**v1** (`configuration.extractor.yaml`):
+**APIOps Toolkit** (`configuration.extractor.yaml`):
 
 ```yaml
 apis:
@@ -153,7 +153,7 @@ apis:
   - orders-api
 ```
 
-**v2** (`configuration.extractor.yaml` — same format and file name):
+**apiops-cli** (`configuration.extractor.yaml` — same format and file name):
 
 ```yaml
 apis:
@@ -161,7 +161,7 @@ apis:
   - orders-api
 ```
 
-The filter YAML format is fully compatible with v1. You can use your existing `configuration.extractor.yaml` as-is with the `--filter` flag:
+The filter YAML format is fully compatible with the APIOps Toolkit. You can use your existing `configuration.extractor.yaml` as-is with the `--filter` flag:
 
 ```bash
 apiops extract \
@@ -172,9 +172,9 @@ apiops extract \
 
 #### Publisher configuration
 
-v1's `configuration.publisher.yaml` maps directly to v2's override files. The structure is the same:
+The APIOps Toolkit's `configuration.publisher.yaml` maps directly to apiops-cli's override files. The structure is the same:
 
-**v1:**
+**APIOps Toolkit:**
 
 ```yaml
 namedValues:
@@ -183,7 +183,7 @@ namedValues:
       value: "prod-value"
 ```
 
-**v2** (`overrides.prod.yaml` — same structure):
+**apiops-cli** (`overrides.prod.yaml` — same structure):
 
 ```yaml
 namedValues:
@@ -203,7 +203,7 @@ apiops publish \
 
 ### 6. Test with dry-run
 
-Before your first real publish with v2, always preview:
+Before your first real publish with apiops-cli, always preview:
 
 ```bash
 apiops publish \
@@ -220,7 +220,7 @@ Review the output to confirm the correct resources would be created, updated, or
 
 ## New Features to Adopt
 
-After migration, take advantage of v2-only capabilities:
+After migration, take advantage of apiops-cli capabilities:
 
 ### Incremental publish
 
@@ -252,7 +252,7 @@ apiops publish --format json ... | jq '.summary'
 
 ### Transitive dependency filtering
 
-v2 automatically includes resources that your filtered APIs depend on (backends, named values, policy fragments). No need to manually list every dependency.
+apiops-cli automatically includes resources that your filtered APIs depend on (backends, named values, policy fragments). No need to manually list every dependency.
 
 ```bash
 apiops extract --filter filter.yaml  # includes deps by default
@@ -276,10 +276,10 @@ apiops extract --cloud usgov ...
 |-------|-------|-----|
 | `apiops: command not found` | CLI not installed globally | Run `npm install -g @peterhauge/apiops-cli` |
 | Artifacts not recognized | Unexpected directory structure | Verify your artifacts follow the standard layout (`apis/{name}/apiInformation.json`, etc.) |
-| Authentication fails in pipeline | v1 used service connection env vars; v2 uses `DefaultAzureCredential` | See [Authentication Guide](./authentication.md). For GitHub Actions, use `azure/login` with OIDC. For Azure DevOps, use `AzureCLI@2` task. |
-| Override values not applied | Wrong override file format or path | Check YAML structure matches v2 format. Pass with `--overrides <path>`. |
-| Extra resources published | v2 supports more resource types than v1 | This is expected. v2 extracts additional resource types (e.g., `GlobalSchema`, `ApiWiki`). Review with `--dry-run`. |
-| `--delete-unmatched` removes unexpected resources | v2 sees more resource types | Run `--dry-run --delete-unmatched` first. Consider using `--commit-id` for safer incremental deploys. |
+| Authentication fails in pipeline | APIOps Toolkit used service connection env vars; apiops-cli uses `DefaultAzureCredential` | See [Authentication Guide](./authentication.md). For GitHub Actions, use `azure/login` with OIDC. For Azure DevOps, use `AzureCLI@2` task. |
+| Override values not applied | Wrong override file format or path | Check YAML structure matches apiops-cli format. Pass with `--overrides <path>`. |
+| Extra resources published | apiops-cli supports more resource types than the APIOps Toolkit | This is expected. apiops-cli extracts additional resource types (e.g., `GlobalSchema`, `ApiWiki`). Review with `--dry-run`. |
+| `--delete-unmatched` removes unexpected resources | apiops-cli sees more resource types | Run `--dry-run --delete-unmatched` first. Consider using `--commit-id` for safer incremental deploys. |
 
 ---
 

--- a/docs/guides/migration-from-v1.md
+++ b/docs/guides/migration-from-v1.md
@@ -148,20 +148,20 @@ Replace the v1 pipeline tasks/actions with v2 CLI commands.
 **v1** (`configuration.extractor.yaml`):
 
 ```yaml
-apiNames:
+apis:
   - payments-api
   - orders-api
 ```
 
-**v2** (filter YAML — same format, different file name convention):
+**v2** (`configuration.extractor.yaml` — same format and file name):
 
 ```yaml
-apiNames:
+apis:
   - payments-api
   - orders-api
 ```
 
-The filter YAML format is compatible. Rename the file if you prefer the v2 convention, and pass it with `--filter`:
+The filter YAML format is fully compatible with v1. You can use your existing `configuration.extractor.yaml` as-is with the `--filter` flag:
 
 ```bash
 apiops extract \

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -17,7 +17,7 @@ flowchart TD
 |----------|--------|---------|
 | **1 (highest)** | CLI flags | `--resource-group my-rg` |
 | **2** | Environment variables | `AZURE_SUBSCRIPTION_ID=...` |
-| **3** | YAML config files | `configuration.extract.yaml`, `configuration.dev.yaml` |
+| **3** | YAML config files | `configuration.extractor.yaml`, `configuration.dev.yaml` |
 | **4 (lowest)** | Default values | `--output ./apim-artifacts` |
 
 For example, if `AZURE_SUBSCRIPTION_ID` is set as an environment variable but `--subscription-id` is also passed on the command line, the CLI flag wins.
@@ -109,16 +109,16 @@ See [Authentication Guide](../guides/authentication.md) for details on each auth
 
 ### Filter Configuration
 
-**File:** `configuration.extract.yaml` (or any path passed to `--filter`)
+**File:** `configuration.extractor.yaml` (or any path passed to `--filter`)
 
 Controls which resources are extracted. See [Filtering Resources](../guides/filtering-resources.md) for the full reference.
 
 ```yaml
-# configuration.extract.yaml
-apiNames:
+# configuration.extractor.yaml
+apis:
   - petstore-api
   - orders-api
-backendNames:
+backends:
   - petstore-backend
 ```
 

--- a/specs/contracts/cli-commands.md
+++ b/specs/contracts/cli-commands.md
@@ -97,7 +97,7 @@ Initialize repository structure and CI/CD pipeline configuration.
 - `.github/workflows/extract.yml` and `publish.yml` (for `github-actions`)
 - `.azdo/pipelines/extract.yml` and `publish.yml` (for `azure-devops`)
 - `apim-artifacts/` directory (empty, with `.gitkeep`)
-- `configuration.extract.yaml` (sample filter file)
+- `configuration.extractor.yaml` (sample filter file)
 - `configuration.{env}.yaml` (sample override files)
 
 ---

--- a/src/lib/config-loader.ts
+++ b/src/lib/config-loader.ts
@@ -42,53 +42,53 @@ export async function loadFilterConfig(filePath: string): Promise<FilterConfig |
     // Validate structure — each field must be an array of strings
     const config: FilterConfig = {};
 
-    if (parsed.apiNames !== undefined) {
-      config.apiNames = assertStringArray(parsed.apiNames, 'apiNames');
+    if (parsed.apis !== undefined) {
+      config.apis = assertStringArray(parsed.apis, 'apis');
     }
-    if (parsed.backendNames !== undefined) {
-      config.backendNames = assertStringArray(parsed.backendNames, 'backendNames');
+    if (parsed.backends !== undefined) {
+      config.backends = assertStringArray(parsed.backends, 'backends');
     }
-    if (parsed.productNames !== undefined) {
-      config.productNames = assertStringArray(parsed.productNames, 'productNames');
+    if (parsed.products !== undefined) {
+      config.products = assertStringArray(parsed.products, 'products');
     }
-    if (parsed.namedValueNames !== undefined) {
-      config.namedValueNames = assertStringArray(parsed.namedValueNames, 'namedValueNames');
+    if (parsed.namedValues !== undefined) {
+      config.namedValues = assertStringArray(parsed.namedValues, 'namedValues');
     }
-    if (parsed.loggerNames !== undefined) {
-      config.loggerNames = assertStringArray(parsed.loggerNames, 'loggerNames');
+    if (parsed.loggers !== undefined) {
+      config.loggers = assertStringArray(parsed.loggers, 'loggers');
     }
-    if (parsed.diagnosticNames !== undefined) {
-      config.diagnosticNames = assertStringArray(parsed.diagnosticNames, 'diagnosticNames');
+    if (parsed.diagnostics !== undefined) {
+      config.diagnostics = assertStringArray(parsed.diagnostics, 'diagnostics');
     }
-    if (parsed.tagNames !== undefined) {
-      config.tagNames = assertStringArray(parsed.tagNames, 'tagNames');
+    if (parsed.tags !== undefined) {
+      config.tags = assertStringArray(parsed.tags, 'tags');
     }
-    if (parsed.policyFragmentNames !== undefined) {
-      config.policyFragmentNames = assertStringArray(parsed.policyFragmentNames, 'policyFragmentNames');
+    if (parsed.policyFragments !== undefined) {
+      config.policyFragments = assertStringArray(parsed.policyFragments, 'policyFragments');
     }
-    if (parsed.gatewayNames !== undefined) {
-      config.gatewayNames = assertStringArray(parsed.gatewayNames, 'gatewayNames');
+    if (parsed.gateways !== undefined) {
+      config.gateways = assertStringArray(parsed.gateways, 'gateways');
     }
-    if (parsed.versionSetNames !== undefined) {
-      config.versionSetNames = assertStringArray(parsed.versionSetNames, 'versionSetNames');
+    if (parsed.versionSets !== undefined) {
+      config.versionSets = assertStringArray(parsed.versionSets, 'versionSets');
     }
-    if (parsed.groupNames !== undefined) {
-      config.groupNames = assertStringArray(parsed.groupNames, 'groupNames');
+    if (parsed.groups !== undefined) {
+      config.groups = assertStringArray(parsed.groups, 'groups');
     }
-    if (parsed.subscriptionNames !== undefined) {
-      config.subscriptionNames = assertStringArray(parsed.subscriptionNames, 'subscriptionNames');
+    if (parsed.subscriptions !== undefined) {
+      config.subscriptions = assertStringArray(parsed.subscriptions, 'subscriptions');
     }
-    if (parsed.schemaNames !== undefined) {
-      config.schemaNames = assertStringArray(parsed.schemaNames, 'schemaNames');
+    if (parsed.schemas !== undefined) {
+      config.schemas = assertStringArray(parsed.schemas, 'schemas');
     }
-    if (parsed.policyRestrictionNames !== undefined) {
-      config.policyRestrictionNames = assertStringArray(parsed.policyRestrictionNames, 'policyRestrictionNames');
+    if (parsed.policyRestrictions !== undefined) {
+      config.policyRestrictions = assertStringArray(parsed.policyRestrictions, 'policyRestrictions');
     }
-    if (parsed.documentationNames !== undefined) {
-      config.documentationNames = assertStringArray(parsed.documentationNames, 'documentationNames');
+    if (parsed.documentations !== undefined) {
+      config.documentations = assertStringArray(parsed.documentations, 'documentations');
     }
-    if (parsed.workspaceNames !== undefined) {
-      config.workspaceNames = assertStringArray(parsed.workspaceNames, 'workspaceNames');
+    if (parsed.workspaces !== undefined) {
+      config.workspaces = assertStringArray(parsed.workspaces, 'workspaces');
     }
     
     logger.debug(`Loaded filter config from ${filePath}`);
@@ -132,9 +132,22 @@ export async function loadOverrideConfig(filePath: string): Promise<OverrideConf
 
 /**
  * Normalize toolkit-format override sections into the internal keyed-map shape.
+ * Ignores `apimServiceName` (Toolkit uses it for target APIM instance; CLI uses --service-name flag instead).
  */
 function normalizeOverrideConfig(parsed: Record<string, unknown>): OverrideConfig {
   const normalized: OverrideConfig = {};
+
+  // Log and ignore apimServiceName — Toolkit uses this for target APIM instance,
+  // but CLI uses --service-name flag instead.
+  if (parsed.apimServiceName !== undefined) {
+    const serviceName = typeof parsed.apimServiceName === 'string'
+      ? parsed.apimServiceName
+      : JSON.stringify(parsed.apimServiceName);
+    logger.info(
+      `Override config contains 'apimServiceName' ("${serviceName}"). ` +
+      `The CLI uses --service-name instead; this field will be ignored.`
+    );
+  }
 
   const namedValues = normalizeOverrideSection(parsed.namedValues, 'namedValues');
   const backends = normalizeOverrideSection(parsed.backends, 'backends');

--- a/src/lib/config-loader.ts
+++ b/src/lib/config-loader.ts
@@ -116,6 +116,7 @@ const FILTER_KEY_ALIASES: Record<FilterYamlKey, string> = {
   groups: 'groupNames',
   subscriptions: 'subscriptionNames',
   schemas: 'schemaNames',
+  policies: 'policyNames',
   policyRestrictions: 'policyRestrictionNames',
   documentations: 'documentationNames',
   workspaces: 'workspaceNames',
@@ -320,34 +321,42 @@ const OVERRIDE_CHILD_SECTIONS: Record<string, Set<string>> = {
  * Normalize one override section into OverrideSection format.
  * Supports Toolkit list format: `[{ name, properties, ...childSections }]`
  * Recursively parses nested child sections.
+ *
+ * @param section - The raw YAML value for this section
+ * @param displayPath - Full dotted path for error messages (e.g., "apis.my-api.operations")
+ * @param sectionKind - Bare section key for child lookup (e.g., "operations")
  */
 function normalizeOverrideSectionRecursive(
   section: unknown,
-  sectionName: string
+  displayPath: string,
+  sectionKind?: string
 ): OverrideSection | undefined {
+  // Use sectionKind for child lookup; fall back to displayPath for top-level calls
+  const lookupKey = sectionKind ?? displayPath;
+
   if (section === undefined || section === null) {
     return undefined;
   }
 
   if (!Array.isArray(section)) {
     throw new Error(
-      `Invalid overrides.${sectionName}: expected an array in toolkit format ` +
+      `Invalid overrides.${displayPath}: expected an array in toolkit format ` +
       `([ { name, properties } ]), got ${typeof section}.`
     );
   }
 
   const normalized: OverrideSection = {};
-  const childKeys = OVERRIDE_CHILD_SECTIONS[sectionName] ?? new Set<string>();
+  const childKeys = OVERRIDE_CHILD_SECTIONS[lookupKey] ?? new Set<string>();
 
   for (const item of section) {
     if (!isPlainObject(item)) {
-      logger.warn(`Ignoring invalid item in overrides.${sectionName}; expected object.`);
+      logger.warn(`Ignoring invalid item in overrides.${displayPath}; expected object.`);
       continue;
     }
 
     const name = item.name;
     if (typeof name !== 'string' || name.trim().length === 0) {
-      logger.warn(`Ignoring item in overrides.${sectionName}; "name" is required.`);
+      logger.warn(`Ignoring item in overrides.${displayPath}; "name" is required.`);
       continue;
     }
 
@@ -356,7 +365,7 @@ function normalizeOverrideSectionRecursive(
     if (item.properties !== undefined && item.properties !== null) {
       if (!isPlainObject(item.properties)) {
         logger.warn(
-          `Ignoring item '${name}' in overrides.${sectionName}; ` +
+          `Ignoring item '${name}' in overrides.${displayPath}; ` +
           `"properties" must be an object, got ${typeof item.properties}.`
         );
         continue;
@@ -369,7 +378,7 @@ function normalizeOverrideSectionRecursive(
       );
       if (Object.keys(fallbackFields).length > 0) {
         logger.debug(
-          `Item '${name}' in overrides.${sectionName} is missing 'properties'; using fields directly.`
+          `Item '${name}' in overrides.${displayPath} is missing 'properties'; using fields directly.`
         );
         properties = fallbackFields;
       } else {
@@ -382,7 +391,11 @@ function normalizeOverrideSectionRecursive(
     for (const childKey of childKeys) {
       const childValue: unknown = item[childKey];
       if (childValue !== undefined) {
-        const childSection = normalizeOverrideSectionRecursive(childValue, `${sectionName}.${name}.${childKey}`);
+        const childSection = normalizeOverrideSectionRecursive(
+          childValue,
+          `${displayPath}.${name}.${childKey}`,
+          childKey
+        );
         if (childSection !== undefined) {
           if (!children) children = {};
           children[childKey] = childSection;
@@ -396,11 +409,11 @@ function normalizeOverrideSectionRecursive(
     // Only add entry if it has properties or children
     if (Object.keys(properties).length > 0 || children) {
       if (normalized[name] !== undefined) {
-        logger.warn(`Duplicate name '${name}' in overrides.${sectionName}; later entry overwrites earlier one.`);
+        logger.warn(`Duplicate name '${name}' in overrides.${displayPath}; later entry overwrites earlier one.`);
       }
       normalized[name] = entry;
     } else {
-      logger.warn(`Ignoring item '${name}' in overrides.${sectionName}; no override properties or child sections.`);
+      logger.warn(`Ignoring item '${name}' in overrides.${displayPath}; no override properties or child sections.`);
     }
   }
 

--- a/src/lib/config-loader.ts
+++ b/src/lib/config-loader.ts
@@ -7,11 +7,9 @@
 
 import * as fs from 'node:fs/promises';
 import * as yaml from 'js-yaml';
-import { FilterConfig, OverrideConfig } from '../models/config.js';
+import { FilterConfig, OverrideConfig, OverrideSection, OverrideEntry, ApiSubFilter, WorkspaceSubFilter } from '../models/config.js';
 import { logger } from './logger.js';
 
-/** Internal normalized override shape keyed by resource name. */
-type OverrideSection = Record<string, Record<string, unknown>>;
 
 /**
  * Assert that a value is an array of strings. Throws on type mismatch.
@@ -31,14 +29,80 @@ function assertStringArray(value: unknown, fieldName: string): string[] {
 }
 
 /**
+ * Parse a filter array that may contain both string entries and nested object entries.
+ * - String entries: resource name to include (all sub-resources included)
+ * - Object entries: `{ name: { subResource: [...] } }` format (Toolkit nested filtering)
+ *
+ * Returns extracted names (string[]) and sub-filter map.
+ */
+function parseFilterArrayWithNested(
+  value: unknown,
+  fieldName: string
+): { names: string[]; subFilters: Record<string, Record<string, string[]>> } {
+  if (!Array.isArray(value)) {
+    throw new Error(`${fieldName} must be an array, got ${typeof value}`);
+  }
+
+  const names: string[] = [];
+  const subFilters: Record<string, Record<string, string[]>> = {};
+
+  for (let i = 0; i < value.length; i++) {
+    const item: unknown = value[i];
+
+    if (typeof item === 'string') {
+      names.push(item);
+      continue;
+    }
+
+    if (isPlainObject(item)) {
+      // Object entry: key is the resource name, value is sub-filter config
+      const keys = Object.keys(item);
+      if (keys.length !== 1) {
+        throw new Error(
+          `${fieldName}[${i}] object entry must have exactly one key (the resource name), ` +
+          `got ${keys.length} keys: ${keys.join(', ')}`
+        );
+      }
+      const name = keys[0];
+      names.push(name);
+
+      const subConfig = item[name];
+      if (isPlainObject(subConfig)) {
+        const subFilter: Record<string, string[]> = {};
+        for (const [subKey, subValue] of Object.entries(subConfig)) {
+          if (subValue === undefined || subValue === null) continue;
+          subFilter[subKey] = assertStringArray(subValue, `${fieldName}[${i}].${name}.${subKey}`);
+        }
+        if (Object.keys(subFilter).length > 0) {
+          subFilters[name] = subFilter;
+        }
+      } else if (subConfig !== undefined && subConfig !== null) {
+        logger.warn(
+          `${fieldName}[${i}]: nested value for '${name}' should be an object with sub-resource arrays; ignoring.`
+        );
+      }
+      continue;
+    }
+
+    throw new Error(
+      `${fieldName}[${i}] must be a string or object, got ${typeof item}`
+    );
+  }
+
+  return { names, subFilters };
+}
+
+/**
  * Load and parse a filter configuration YAML file.
  * Returns undefined if file doesn't exist.
  */
 /**
  * Mapping from FilterConfig field to its legacy alias (the old *Names key).
  * Both the Toolkit-style key and the legacy alias are accepted during parsing.
+ * Only includes fields that appear as YAML keys (not internal computed fields).
  */
-const FILTER_KEY_ALIASES: Record<keyof FilterConfig, string> = {
+type FilterYamlKey = Exclude<keyof FilterConfig, 'apiSubFilters' | 'workspaceSubFilters'>;
+const FILTER_KEY_ALIASES: Record<FilterYamlKey, string> = {
   apis: 'apiNames',
   backends: 'backendNames',
   products: 'productNames',
@@ -57,17 +121,20 @@ const FILTER_KEY_ALIASES: Record<keyof FilterConfig, string> = {
   workspaces: 'workspaceNames',
 };
 
+/** Fields that support nested sub-resource filtering (object entries) */
+const NESTED_FILTER_FIELDS: Set<FilterYamlKey> = new Set(['apis', 'workspaces']);
+
 export async function loadFilterConfig(filePath: string): Promise<FilterConfig | undefined> {
   try {
     const content = await fs.readFile(filePath, 'utf-8');
     const parsed = (yaml.load(content) ?? {}) as Record<string, unknown>;
     
-    // Validate structure — each field must be an array of strings.
+    // Validate structure — each field must be an array of strings (or nested objects for apis/workspaces).
     // Accept both Toolkit-style keys (e.g. "apis") and legacy aliases (e.g. "apiNames").
     const config: FilterConfig = {};
 
     for (const [field, legacyAlias] of Object.entries(FILTER_KEY_ALIASES)) {
-      const key = field as keyof FilterConfig;
+      const key = field as FilterYamlKey;
       const toolkitValue = parsed[field];
       const legacyValue = parsed[legacyAlias];
 
@@ -78,14 +145,75 @@ export async function loadFilterConfig(filePath: string): Promise<FilterConfig |
         );
       }
 
-      if (toolkitValue !== undefined) {
-        config[key] = assertStringArray(toolkitValue, field);
-      } else if (legacyValue !== undefined) {
+      const rawValue = toolkitValue ?? legacyValue;
+      const sourceKey = toolkitValue !== undefined ? field : legacyAlias;
+
+      if (rawValue === undefined) continue;
+
+      if (legacyValue !== undefined) {
         logger.warn(
           `Filter key '${legacyAlias}' is deprecated; use '${field}' instead ` +
           `(APIOps Toolkit format).`
         );
-        config[key] = assertStringArray(legacyValue, legacyAlias);
+      }
+
+      if (NESTED_FILTER_FIELDS.has(key) && key === 'apis') {
+        const { names, subFilters } = parseFilterArrayWithNested(rawValue, sourceKey);
+        config.apis = names;
+        if (Object.keys(subFilters).length > 0) {
+          config.apiSubFilters = {};
+          const validApiSubKeys = ['operations', 'diagnostics', 'schemas', 'releases'] as const;
+          for (const [apiName, sf] of Object.entries(subFilters)) {
+            const apiSub: ApiSubFilter = {};
+            for (const subKey of validApiSubKeys) {
+              if (subKey in sf) {
+                apiSub[subKey] = sf[subKey];
+              }
+            }
+            // Warn about unsupported sub-filter keys
+            for (const k of Object.keys(sf)) {
+              if (!(validApiSubKeys as readonly string[]).includes(k)) {
+                logger.warn(`Unknown API sub-filter key '${k}' for API '${apiName}'; ignoring.`);
+              }
+            }
+            config.apiSubFilters[apiName] = apiSub;
+          }
+        }
+      } else if (NESTED_FILTER_FIELDS.has(key) && key === 'workspaces') {
+        const { names, subFilters } = parseFilterArrayWithNested(rawValue, sourceKey);
+        config.workspaces = names;
+        if (Object.keys(subFilters).length > 0) {
+          config.workspaceSubFilters = {};
+          const validWsSubKeys = ['apis', 'backends', 'diagnostics', 'groups', 'loggers',
+            'namedValues', 'policyFragments', 'products', 'subscriptions', 'tags', 'versionSets'] as const;
+          for (const [wsName, sf] of Object.entries(subFilters)) {
+            const wsSub: WorkspaceSubFilter = {};
+            for (const wsField of validWsSubKeys) {
+              if (wsField in sf) {
+                (wsSub as Record<string, string[]>)[wsField] = sf[wsField];
+              }
+            }
+            for (const k of Object.keys(sf)) {
+              if (!(validWsSubKeys as readonly string[]).includes(k)) {
+                logger.warn(`Unknown workspace sub-filter key '${k}' for workspace '${wsName}'; ignoring.`);
+              }
+            }
+            config.workspaceSubFilters[wsName] = wsSub;
+          }
+        }
+      } else {
+        (config as Record<string, unknown>)[key] = assertStringArray(rawValue, sourceKey);
+      }
+    }
+
+    // Warn about unknown top-level keys
+    const knownKeys = new Set([
+      ...Object.keys(FILTER_KEY_ALIASES),
+      ...Object.values(FILTER_KEY_ALIASES),
+    ]);
+    for (const key of Object.keys(parsed)) {
+      if (!knownKeys.has(key)) {
+        logger.warn(`Unknown filter config key '${key}'; ignoring. Did you mean one of: ${Object.keys(FILTER_KEY_ALIASES).join(', ')}?`);
       }
     }
     
@@ -130,6 +258,7 @@ export async function loadOverrideConfig(filePath: string): Promise<OverrideConf
 
 /**
  * Normalize toolkit-format override sections into the internal keyed-map shape.
+ * Supports all Toolkit override sections with nested sub-resource overrides.
  * Ignores `apimServiceName` (Toolkit uses it for target APIM instance; CLI uses --service-name flag instead).
  */
 function normalizeOverrideConfig(parsed: Record<string, unknown>): OverrideConfig {
@@ -147,27 +276,52 @@ function normalizeOverrideConfig(parsed: Record<string, unknown>): OverrideConfi
     );
   }
 
-  const namedValues = normalizeOverrideSection(parsed.namedValues, 'namedValues');
-  const backends = normalizeOverrideSection(parsed.backends, 'backends');
-  const apis = normalizeOverrideSection(parsed.apis, 'apis');
-  const diagnostics = normalizeOverrideSection(parsed.diagnostics, 'diagnostics');
-  const loggers = normalizeOverrideSection(parsed.loggers, 'loggers');
+  // All supported Toolkit override sections
+  const ALL_OVERRIDE_SECTIONS: (keyof OverrideConfig)[] = [
+    'namedValues', 'backends', 'apis', 'diagnostics', 'loggers',
+    'policies', 'gateways', 'versionSets', 'groups', 'subscriptions',
+    'products', 'tags', 'policyFragments', 'workspaces',
+  ];
 
-  if (namedValues !== undefined) normalized.namedValues = namedValues;
-  if (backends !== undefined) normalized.backends = backends;
-  if (apis !== undefined) normalized.apis = apis;
-  if (diagnostics !== undefined) normalized.diagnostics = diagnostics;
-  if (loggers !== undefined) normalized.loggers = loggers;
+  for (const sectionName of ALL_OVERRIDE_SECTIONS) {
+    const rawSection: unknown = parsed[sectionName];
+    const section = normalizeOverrideSectionRecursive(rawSection, sectionName);
+    if (section !== undefined) {
+      normalized[sectionName] = section;
+    }
+  }
+
+  // Warn about unknown top-level keys
+  const knownKeys = new Set<string>([...ALL_OVERRIDE_SECTIONS, 'apimServiceName']);
+  for (const key of Object.keys(parsed)) {
+    if (!knownKeys.has(key)) {
+      logger.warn(`Unknown override config key '${key}'; ignoring.`);
+    }
+  }
 
   return normalized;
 }
 
 /**
- * Normalize one override section into keyed-map format.
- * Supports toolkit list format only:
- * - `{ backends: [{ name: myBackend, properties: { url: ... } }] }`
+ * Known child section keys for each parent override type.
+ * Used to distinguish nested sub-resource overrides from regular properties.
  */
-function normalizeOverrideSection(
+const OVERRIDE_CHILD_SECTIONS: Record<string, Set<string>> = {
+  apis: new Set(['diagnostics', 'operations', 'policies', 'releases']),
+  workspaces: new Set([
+    'apis', 'backends', 'diagnostics', 'groups', 'loggers',
+    'namedValues', 'policyFragments', 'products', 'subscriptions', 'tags', 'versionSets',
+  ]),
+  products: new Set(['policies']),
+  operations: new Set(['policies']),
+};
+
+/**
+ * Normalize one override section into OverrideSection format.
+ * Supports Toolkit list format: `[{ name, properties, ...childSections }]`
+ * Recursively parses nested child sections.
+ */
+function normalizeOverrideSectionRecursive(
   section: unknown,
   sectionName: string
 ): OverrideSection | undefined {
@@ -183,6 +337,7 @@ function normalizeOverrideSection(
   }
 
   const normalized: OverrideSection = {};
+  const childKeys = OVERRIDE_CHILD_SECTIONS[sectionName] ?? new Set<string>();
 
   for (const item of section) {
     if (!isPlainObject(item)) {
@@ -196,27 +351,60 @@ function normalizeOverrideSection(
       continue;
     }
 
-    if (isPlainObject(item.properties)) {
-      normalized[name] = item.properties;
-      continue;
+    // Extract properties
+    let properties: Record<string, unknown>;
+    if (item.properties !== undefined && item.properties !== null) {
+      if (!isPlainObject(item.properties)) {
+        logger.warn(
+          `Ignoring item '${name}' in overrides.${sectionName}; ` +
+          `"properties" must be an object, got ${typeof item.properties}.`
+        );
+        continue;
+      }
+      properties = item.properties;
+    } else {
+      // Fallback: use fields directly (excluding 'name' and known child sections)
+      const fallbackFields = Object.fromEntries(
+        Object.entries(item).filter(([key]) => key !== 'name' && key !== 'properties' && !childKeys.has(key))
+      );
+      if (Object.keys(fallbackFields).length > 0) {
+        logger.debug(
+          `Item '${name}' in overrides.${sectionName} is missing 'properties'; using fields directly.`
+        );
+        properties = fallbackFields;
+      } else {
+        properties = {};
+      }
     }
 
-    logger.debug(
-      `Item in overrides.${sectionName} is missing a 'properties' object; using fields directly.`,
-      { name }
-    );
-    const fallbackFields = Object.fromEntries(
-      Object.entries(item).filter(([key]) => key !== 'name' && key !== 'properties')
-    );
-    if (Object.keys(fallbackFields).length === 0) {
-      logger.warn(`Ignoring item in overrides.${sectionName}; no override fields were provided.`, { name });
-      continue;
+    // Parse nested child sections
+    let children: Record<string, OverrideSection> | undefined;
+    for (const childKey of childKeys) {
+      const childValue: unknown = item[childKey];
+      if (childValue !== undefined) {
+        const childSection = normalizeOverrideSectionRecursive(childValue, `${sectionName}.${name}.${childKey}`);
+        if (childSection !== undefined) {
+          if (!children) children = {};
+          children[childKey] = childSection;
+        }
+      }
     }
 
-    normalized[name] = fallbackFields;
+    const entry: OverrideEntry = { properties };
+    if (children) entry.children = children;
+
+    // Only add entry if it has properties or children
+    if (Object.keys(properties).length > 0 || children) {
+      if (normalized[name] !== undefined) {
+        logger.warn(`Duplicate name '${name}' in overrides.${sectionName}; later entry overwrites earlier one.`);
+      }
+      normalized[name] = entry;
+    } else {
+      logger.warn(`Ignoring item '${name}' in overrides.${sectionName}; no override properties or child sections.`);
+    }
   }
 
-  return normalized;
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/src/lib/config-loader.ts
+++ b/src/lib/config-loader.ts
@@ -34,61 +34,59 @@ function assertStringArray(value: unknown, fieldName: string): string[] {
  * Load and parse a filter configuration YAML file.
  * Returns undefined if file doesn't exist.
  */
+/**
+ * Mapping from FilterConfig field to its legacy alias (the old *Names key).
+ * Both the Toolkit-style key and the legacy alias are accepted during parsing.
+ */
+const FILTER_KEY_ALIASES: Record<keyof FilterConfig, string> = {
+  apis: 'apiNames',
+  backends: 'backendNames',
+  products: 'productNames',
+  namedValues: 'namedValueNames',
+  loggers: 'loggerNames',
+  diagnostics: 'diagnosticNames',
+  tags: 'tagNames',
+  policyFragments: 'policyFragmentNames',
+  gateways: 'gatewayNames',
+  versionSets: 'versionSetNames',
+  groups: 'groupNames',
+  subscriptions: 'subscriptionNames',
+  schemas: 'schemaNames',
+  policyRestrictions: 'policyRestrictionNames',
+  documentations: 'documentationNames',
+  workspaces: 'workspaceNames',
+};
+
 export async function loadFilterConfig(filePath: string): Promise<FilterConfig | undefined> {
   try {
     const content = await fs.readFile(filePath, 'utf-8');
     const parsed = (yaml.load(content) ?? {}) as Record<string, unknown>;
     
-    // Validate structure — each field must be an array of strings
+    // Validate structure — each field must be an array of strings.
+    // Accept both Toolkit-style keys (e.g. "apis") and legacy aliases (e.g. "apiNames").
     const config: FilterConfig = {};
 
-    if (parsed.apis !== undefined) {
-      config.apis = assertStringArray(parsed.apis, 'apis');
-    }
-    if (parsed.backends !== undefined) {
-      config.backends = assertStringArray(parsed.backends, 'backends');
-    }
-    if (parsed.products !== undefined) {
-      config.products = assertStringArray(parsed.products, 'products');
-    }
-    if (parsed.namedValues !== undefined) {
-      config.namedValues = assertStringArray(parsed.namedValues, 'namedValues');
-    }
-    if (parsed.loggers !== undefined) {
-      config.loggers = assertStringArray(parsed.loggers, 'loggers');
-    }
-    if (parsed.diagnostics !== undefined) {
-      config.diagnostics = assertStringArray(parsed.diagnostics, 'diagnostics');
-    }
-    if (parsed.tags !== undefined) {
-      config.tags = assertStringArray(parsed.tags, 'tags');
-    }
-    if (parsed.policyFragments !== undefined) {
-      config.policyFragments = assertStringArray(parsed.policyFragments, 'policyFragments');
-    }
-    if (parsed.gateways !== undefined) {
-      config.gateways = assertStringArray(parsed.gateways, 'gateways');
-    }
-    if (parsed.versionSets !== undefined) {
-      config.versionSets = assertStringArray(parsed.versionSets, 'versionSets');
-    }
-    if (parsed.groups !== undefined) {
-      config.groups = assertStringArray(parsed.groups, 'groups');
-    }
-    if (parsed.subscriptions !== undefined) {
-      config.subscriptions = assertStringArray(parsed.subscriptions, 'subscriptions');
-    }
-    if (parsed.schemas !== undefined) {
-      config.schemas = assertStringArray(parsed.schemas, 'schemas');
-    }
-    if (parsed.policyRestrictions !== undefined) {
-      config.policyRestrictions = assertStringArray(parsed.policyRestrictions, 'policyRestrictions');
-    }
-    if (parsed.documentations !== undefined) {
-      config.documentations = assertStringArray(parsed.documentations, 'documentations');
-    }
-    if (parsed.workspaces !== undefined) {
-      config.workspaces = assertStringArray(parsed.workspaces, 'workspaces');
+    for (const [field, legacyAlias] of Object.entries(FILTER_KEY_ALIASES)) {
+      const key = field as keyof FilterConfig;
+      const toolkitValue = parsed[field];
+      const legacyValue = parsed[legacyAlias];
+
+      if (toolkitValue !== undefined && legacyValue !== undefined) {
+        throw new Error(
+          `Filter config contains both '${field}' and '${legacyAlias}'. ` +
+          `Use '${field}' (the APIOps Toolkit format).`
+        );
+      }
+
+      if (toolkitValue !== undefined) {
+        config[key] = assertStringArray(toolkitValue, field);
+      } else if (legacyValue !== undefined) {
+        logger.warn(
+          `Filter key '${legacyAlias}' is deprecated; use '${field}' instead ` +
+          `(APIOps Toolkit format).`
+        );
+        config[key] = assertStringArray(legacyValue, legacyAlias);
+      }
     }
     
     logger.debug(`Loaded filter config from ${filePath}`);

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -18,8 +18,41 @@ export interface ExtractConfig {
   otelConfigPath?: string;
 }
 
+/**
+ * Sub-resource filter for an individual API.
+ * Only sub-resources listed here are included; undefined means include all.
+ * An empty array means include NONE of that sub-resource type.
+ */
+export interface ApiSubFilter {
+  operations?: string[];
+  diagnostics?: string[];
+  schemas?: string[];
+  releases?: string[];
+}
+
+/**
+ * Sub-resource filter for an individual workspace.
+ * Specifies exactly which workspace-scoped resources to include.
+ */
+export interface WorkspaceSubFilter {
+  apis?: string[];
+  apiSubFilters?: Record<string, ApiSubFilter>;
+  backends?: string[];
+  diagnostics?: string[];
+  groups?: string[];
+  loggers?: string[];
+  namedValues?: string[];
+  policyFragments?: string[];
+  products?: string[];
+  subscriptions?: string[];
+  tags?: string[];
+  versionSets?: string[];
+}
+
 export interface FilterConfig {
   apis?: string[];
+  /** Per-API sub-resource filters (only for APIs listed with nested object syntax) */
+  apiSubFilters?: Record<string, ApiSubFilter>;
   backends?: string[];
   products?: string[];
   namedValues?: string[];
@@ -35,6 +68,8 @@ export interface FilterConfig {
   policyRestrictions?: string[];
   documentations?: string[];
   workspaces?: string[];
+  /** Per-workspace sub-resource filters (only for workspaces listed with nested object syntax) */
+  workspaceSubFilters?: Record<string, WorkspaceSubFilter>;
 }
 
 export interface PublishConfig {
@@ -48,40 +83,39 @@ export interface PublishConfig {
   otelConfigPath?: string;
 }
 
+/**
+ * A single override entry: properties to deep-merge + optional nested child overrides.
+ */
+export interface OverrideEntry {
+  /** Properties to deep-merge into the resource's ARM DTO */
+  properties: Record<string, unknown>;
+  /** Nested sub-resource override sections (e.g., diagnostics under an API) */
+  children?: Record<string, OverrideSection>;
+}
+
+/** A section of overrides: resource name → override entry */
+export type OverrideSection = Record<string, OverrideEntry>;
+
+/**
+ * Environment-specific override configuration.
+ * Supports all Toolkit override sections with generic property passthrough.
+ * Nested sub-resource overrides (e.g., API diagnostics) are stored in OverrideEntry.children.
+ */
 export interface OverrideConfig {
-  namedValues?: Record<string, NamedValueOverride>;
-  backends?: Record<string, BackendOverride>;
-  apis?: Record<string, ApiOverride>;
-  diagnostics?: Record<string, DiagnosticOverride>;
-  loggers?: Record<string, LoggerOverride>;
-}
-
-export interface NamedValueOverride {
-  value?: string;
-  displayName?: string;
-  tags?: string[];
-  keyVault?: {
-    identityClientId?: string;
-    secretIdentifier?: string;
-  };
-}
-
-export interface BackendOverride {
-  url?: string;
-  credentials?: Record<string, unknown>;
-}
-
-export interface ApiOverride {
-  serviceUrl?: string;
-}
-
-export interface DiagnosticOverride {
-  loggerId?: string;
-}
-
-export interface LoggerOverride {
-  credentials?: Record<string, unknown>;
-  resourceId?: string;
+  namedValues?: OverrideSection;
+  backends?: OverrideSection;
+  apis?: OverrideSection;
+  diagnostics?: OverrideSection;
+  loggers?: OverrideSection;
+  policies?: OverrideSection;
+  gateways?: OverrideSection;
+  versionSets?: OverrideSection;
+  groups?: OverrideSection;
+  subscriptions?: OverrideSection;
+  products?: OverrideSection;
+  tags?: OverrideSection;
+  policyFragments?: OverrideSection;
+  workspaces?: OverrideSection;
 }
 
 export interface InitConfig {

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -65,6 +65,7 @@ export interface FilterConfig {
   groups?: string[];
   subscriptions?: string[];
   schemas?: string[];
+  policies?: string[];
   policyRestrictions?: string[];
   documentations?: string[];
   workspaces?: string[];

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -19,22 +19,22 @@ export interface ExtractConfig {
 }
 
 export interface FilterConfig {
-  apiNames?: string[];
-  backendNames?: string[];
-  productNames?: string[];
-  namedValueNames?: string[];
-  loggerNames?: string[];
-  diagnosticNames?: string[];
-  tagNames?: string[];
-  policyFragmentNames?: string[];
-  gatewayNames?: string[];
-  versionSetNames?: string[];
-  groupNames?: string[];
-  subscriptionNames?: string[];
-  schemaNames?: string[];
-  policyRestrictionNames?: string[];
-  documentationNames?: string[];
-  workspaceNames?: string[];
+  apis?: string[];
+  backends?: string[];
+  products?: string[];
+  namedValues?: string[];
+  loggers?: string[];
+  diagnostics?: string[];
+  tags?: string[];
+  policyFragments?: string[];
+  gateways?: string[];
+  versionSets?: string[];
+  groups?: string[];
+  subscriptions?: string[];
+  schemas?: string[];
+  policyRestrictions?: string[];
+  documentations?: string[];
+  workspaces?: string[];
 }
 
 export interface PublishConfig {

--- a/src/services/filter-service.ts
+++ b/src/services/filter-service.ts
@@ -6,7 +6,7 @@
  * case-insensitive matching, API root-name matching for revisions.
  */
 
-import { FilterConfig } from '../models/config.js';
+import { FilterConfig, ApiSubFilter } from '../models/config.js';
 import { ResourceType } from '../models/resource-types.js';
 import { ResourceDescriptor } from '../models/types.js';
 import { logger } from '../lib/logger.js';
@@ -31,6 +31,7 @@ const FILTER_FIELD_MAP: Partial<Record<ResourceType, keyof FilterConfig>> = {
   [ResourceType.GlobalSchema]: 'schemas',
   [ResourceType.PolicyRestriction]: 'policyRestrictions',
   [ResourceType.Documentation]: 'documentations',
+  [ResourceType.Workspace]: 'workspaces',
 };
 
 /**
@@ -58,6 +59,17 @@ const PARENT_FILTER_MAP: Partial<Record<ResourceType, keyof FilterConfig>> = {
 };
 
 /**
+ * Map API child resource types to their sub-filter key in ApiSubFilter.
+ */
+const API_SUB_FILTER_KEY_MAP: Partial<Record<ResourceType, keyof ApiSubFilter>> = {
+  [ResourceType.ApiOperation]: 'operations',
+  [ResourceType.ApiOperationPolicy]: 'operations',
+  [ResourceType.ApiDiagnostic]: 'diagnostics',
+  [ResourceType.ApiSchema]: 'schemas',
+  [ResourceType.ApiRelease]: 'releases',
+};
+
+/**
  * Determines if a resource should be included based on the filter config.
  *
  * Rules:
@@ -67,6 +79,7 @@ const PARENT_FILTER_MAP: Partial<Record<ResourceType, keyof FilterConfig>> = {
  * - Matching is case-insensitive.
  * - API filter matches root name; all revisions of matching root are included.
  * - Child resources inherit filter from their parent type.
+ * - API sub-resource filters (operations, diagnostics, schemas, releases) are applied when specified.
  */
 export function shouldIncludeResource(
   descriptor: ResourceDescriptor,
@@ -79,7 +92,7 @@ export function shouldIncludeResource(
   // Check direct filter field for this resource type
   const directField = FILTER_FIELD_MAP[descriptor.type];
   if (directField) {
-    return matchesFilter(getNamePart(descriptor.nameParts, 0), filter[directField]);
+    return matchesFilter(getNamePart(descriptor.nameParts, 0), filter[directField] as string[] | undefined);
   }
 
   // Check parent-based filter for child resource types
@@ -87,7 +100,17 @@ export function shouldIncludeResource(
   if (parentField) {
     const parentName = getParentNameForFilter(descriptor);
     if (parentName) {
-      return matchesFilter(parentName, filter[parentField]);
+      // First check: is the parent included?
+      if (!matchesFilter(parentName, filter[parentField] as string[] | undefined)) {
+        return false;
+      }
+
+      // Second check: does the parent have sub-resource filters?
+      if (parentField === 'apis' && filter.apiSubFilters) {
+        return matchesApiSubFilter(descriptor, parentName, filter.apiSubFilters);
+      }
+
+      return true;
     }
   }
 
@@ -98,6 +121,51 @@ export function shouldIncludeResource(
 
   // Unknown types are included by default
   return true;
+}
+
+/**
+ * Check if an API child resource passes the API sub-resource filter.
+ * If the parent API has no sub-filter entry, all children are included.
+ * If the parent API has a sub-filter, only specified children pass.
+ */
+function matchesApiSubFilter(
+  descriptor: ResourceDescriptor,
+  parentApiName: string,
+  apiSubFilters: Record<string, ApiSubFilter>
+): boolean {
+  // Find matching sub-filter using case-insensitive API name
+  const lowerParent = parentApiName.toLowerCase();
+  const matchingKey = Object.keys(apiSubFilters).find(
+    (k) => k.toLowerCase() === lowerParent
+  );
+
+  if (!matchingKey) {
+    // No sub-filter for this API — include all children
+    return true;
+  }
+
+  const subFilter = apiSubFilters[matchingKey];
+  const subFilterKey = API_SUB_FILTER_KEY_MAP[descriptor.type];
+
+  if (!subFilterKey) {
+    // This child type has no sub-filter support (e.g., ApiTag, ApiWiki) — include by default
+    return true;
+  }
+
+  const allowlist = subFilter[subFilterKey];
+  if (allowlist === undefined) {
+    // Sub-filter for this API doesn't specify this child type — include all
+    return true;
+  }
+
+  if (allowlist.length === 0) {
+    // Explicitly empty = exclude all of this child type
+    return false;
+  }
+
+  // Match the child's own name (second name part for ApiOperation, ApiDiagnostic, etc.)
+  const childName = getNamePart(descriptor.nameParts, 1);
+  return matchesFilter(childName, allowlist);
 }
 
 /**

--- a/src/services/filter-service.ts
+++ b/src/services/filter-service.ts
@@ -7,7 +7,7 @@
  */
 
 import { FilterConfig, ApiSubFilter } from '../models/config.js';
-import { ResourceType } from '../models/resource-types.js';
+import { ResourceType, RESOURCE_TYPE_METADATA } from '../models/resource-types.js';
 import { ResourceDescriptor } from '../models/types.js';
 import { logger } from '../lib/logger.js';
 import { getNamePart } from '../lib/resource-path.js';
@@ -29,6 +29,7 @@ const FILTER_FIELD_MAP: Partial<Record<ResourceType, keyof FilterConfig>> = {
   [ResourceType.Group]: 'groups',
   [ResourceType.Subscription]: 'subscriptions',
   [ResourceType.GlobalSchema]: 'schemas',
+  [ResourceType.ServicePolicy]: 'policies',
   [ResourceType.PolicyRestriction]: 'policyRestrictions',
   [ResourceType.Documentation]: 'documentations',
   [ResourceType.Workspace]: 'workspaces',
@@ -92,7 +93,11 @@ export function shouldIncludeResource(
   // Check direct filter field for this resource type
   const directField = FILTER_FIELD_MAP[descriptor.type];
   if (directField) {
-    return matchesFilter(getNamePart(descriptor.nameParts, 0), filter[directField] as string[] | undefined);
+    // Singleton resources (e.g., ServicePolicy) have nameParts: [] — use fixed name from ARM path
+    const resourceName = descriptor.nameParts.length > 0
+      ? getNamePart(descriptor.nameParts, 0)
+      : getSingletonFilterName(descriptor.type);
+    return matchesFilter(resourceName, filter[directField] as string[] | undefined);
   }
 
   // Check parent-based filter for child resource types
@@ -114,13 +119,17 @@ export function shouldIncludeResource(
     }
   }
 
-  // ServicePolicy has no filter — always included
-  if (descriptor.type === ResourceType.ServicePolicy) {
-    return true;
-  }
-
   // Unknown types are included by default
   return true;
+}
+
+/**
+ * Get the fixed singleton name for a resource type from its ARM path.
+ * E.g., ServicePolicy → "policy"
+ */
+function getSingletonFilterName(type: ResourceType): string {
+  const meta = RESOURCE_TYPE_METADATA[type];
+  return meta.armPathSuffix.split('/').pop() ?? '';
 }
 
 /**

--- a/src/services/filter-service.ts
+++ b/src/services/filter-service.ts
@@ -16,21 +16,21 @@ import { getNamePart } from '../lib/resource-path.js';
  * Map resource types to their corresponding FilterConfig field names.
  */
 const FILTER_FIELD_MAP: Partial<Record<ResourceType, keyof FilterConfig>> = {
-  [ResourceType.Api]: 'apiNames',
-  [ResourceType.Backend]: 'backendNames',
-  [ResourceType.Product]: 'productNames',
-  [ResourceType.NamedValue]: 'namedValueNames',
-  [ResourceType.Logger]: 'loggerNames',
-  [ResourceType.Diagnostic]: 'diagnosticNames',
-  [ResourceType.Tag]: 'tagNames',
-  [ResourceType.PolicyFragment]: 'policyFragmentNames',
-  [ResourceType.Gateway]: 'gatewayNames',
-  [ResourceType.VersionSet]: 'versionSetNames',
-  [ResourceType.Group]: 'groupNames',
-  [ResourceType.Subscription]: 'subscriptionNames',
-  [ResourceType.GlobalSchema]: 'schemaNames',
-  [ResourceType.PolicyRestriction]: 'policyRestrictionNames',
-  [ResourceType.Documentation]: 'documentationNames',
+  [ResourceType.Api]: 'apis',
+  [ResourceType.Backend]: 'backends',
+  [ResourceType.Product]: 'products',
+  [ResourceType.NamedValue]: 'namedValues',
+  [ResourceType.Logger]: 'loggers',
+  [ResourceType.Diagnostic]: 'diagnostics',
+  [ResourceType.Tag]: 'tags',
+  [ResourceType.PolicyFragment]: 'policyFragments',
+  [ResourceType.Gateway]: 'gateways',
+  [ResourceType.VersionSet]: 'versionSets',
+  [ResourceType.Group]: 'groups',
+  [ResourceType.Subscription]: 'subscriptions',
+  [ResourceType.GlobalSchema]: 'schemas',
+  [ResourceType.PolicyRestriction]: 'policyRestrictions',
+  [ResourceType.Documentation]: 'documentations',
 };
 
 /**
@@ -38,23 +38,23 @@ const FILTER_FIELD_MAP: Partial<Record<ResourceType, keyof FilterConfig>> = {
  * If the parent (e.g., Api or Product) passes the filter, all children are included.
  */
 const PARENT_FILTER_MAP: Partial<Record<ResourceType, keyof FilterConfig>> = {
-  [ResourceType.ApiPolicy]: 'apiNames',
-  [ResourceType.ApiTag]: 'apiNames',
-  [ResourceType.ApiDiagnostic]: 'apiNames',
-  [ResourceType.ApiOperation]: 'apiNames',
-  [ResourceType.ApiOperationPolicy]: 'apiNames',
-  [ResourceType.ApiSchema]: 'apiNames',
-  [ResourceType.ApiRelease]: 'apiNames',
-  [ResourceType.ApiTagDescription]: 'apiNames',
-  [ResourceType.ApiWiki]: 'apiNames',
-  [ResourceType.GraphQLResolver]: 'apiNames',
-  [ResourceType.GraphQLResolverPolicy]: 'apiNames',
-  [ResourceType.ProductPolicy]: 'productNames',
-  [ResourceType.ProductApi]: 'productNames',
-  [ResourceType.ProductGroup]: 'productNames',
-  [ResourceType.ProductTag]: 'productNames',
-  [ResourceType.ProductWiki]: 'productNames',
-  [ResourceType.GatewayApi]: 'gatewayNames',
+  [ResourceType.ApiPolicy]: 'apis',
+  [ResourceType.ApiTag]: 'apis',
+  [ResourceType.ApiDiagnostic]: 'apis',
+  [ResourceType.ApiOperation]: 'apis',
+  [ResourceType.ApiOperationPolicy]: 'apis',
+  [ResourceType.ApiSchema]: 'apis',
+  [ResourceType.ApiRelease]: 'apis',
+  [ResourceType.ApiTagDescription]: 'apis',
+  [ResourceType.ApiWiki]: 'apis',
+  [ResourceType.GraphQLResolver]: 'apis',
+  [ResourceType.GraphQLResolverPolicy]: 'apis',
+  [ResourceType.ProductPolicy]: 'products',
+  [ResourceType.ProductApi]: 'products',
+  [ResourceType.ProductGroup]: 'products',
+  [ResourceType.ProductTag]: 'products',
+  [ResourceType.ProductWiki]: 'products',
+  [ResourceType.GatewayApi]: 'gateways',
 };
 
 /**
@@ -108,7 +108,7 @@ export function shouldIncludeResource(
 function getParentNameForFilter(descriptor: ResourceDescriptor): string | undefined {
   const parentName = getNamePart(descriptor.nameParts, 0);
   // API children need revision suffix stripped (e.g. "my-api;rev=2" → "my-api")
-  return PARENT_FILTER_MAP[descriptor.type] === 'apiNames'
+  return PARENT_FILTER_MAP[descriptor.type] === 'apis'
     ? extractRootApiName(parentName)
     : parentName;
 }

--- a/src/services/init-service.ts
+++ b/src/services/init-service.ts
@@ -198,7 +198,7 @@ class InitServiceImpl implements InitService {
     // Check for config files
     const filterConfig = path.join(
       config.outputDir,
-      'configuration.extract.yaml'
+      'configuration.extractor.yaml'
     );
     if (await this.fileExists(filterConfig)) {
       conflictingFiles.push(filterConfig);
@@ -375,9 +375,9 @@ class InitServiceImpl implements InitService {
   ): Promise<void> {
     // Filter config
     const filterContent = generateFilterConfig();
-    const filterPath = path.join(config.outputDir, 'configuration.extract.yaml');
+    const filterPath = path.join(config.outputDir, 'configuration.extractor.yaml');
     await fs.writeFile(filterPath, filterContent);
-    generatedFiles.configs.push('configuration.extract.yaml');
+    generatedFiles.configs.push('configuration.extractor.yaml');
 
     // Override configs for each environment
     for (const env of config.environments) {

--- a/src/services/override-merger.ts
+++ b/src/services/override-merger.ts
@@ -8,10 +8,10 @@
  */
 
 import { ResourceDescriptor } from '../models/types.js';
-import { ResourceType } from '../models/resource-types.js';
+import { ResourceType, RESOURCE_TYPE_METADATA } from '../models/resource-types.js';
 import { OverrideConfig, OverrideSection, OverrideEntry } from '../models/config.js';
 import { logger } from '../lib/logger.js';
-import { getNameFromNameParts } from '../lib/resource-path.js';
+import { getNameFromNameParts, isSingletonType } from '../lib/resource-path.js';
 
 /**
  * Map resource types to their top-level override config section key.
@@ -98,13 +98,15 @@ export function applyOverrides(
 
 /**
  * Apply override from a direct section match.
+ * For singleton resources (e.g., ServicePolicy with nameParts: []),
+ * uses the fixed singleton name from the ARM path (e.g., "policy").
  */
 function applyFromSection(
   descriptor: ResourceDescriptor,
   json: Record<string, unknown>,
   section: OverrideSection
 ): Record<string, unknown> {
-  const resourceName = getNameFromNameParts(descriptor.nameParts);
+  const resourceName = getSingletonOrNamePartName(descriptor);
   const entry = findEntryByName(section, resourceName);
 
   if (!entry) {
@@ -116,7 +118,25 @@ function applyFromSection(
   }
 
   // ARM resources have all overridable fields inside 'properties'
-  const wrappedOverride = { properties: entry.properties };
+  let overrideProperties = entry.properties;
+
+  // Strip apiRevision and isCurrent from API overrides — matches Toolkit behavior.
+  // These fields should not be overridden per environment.
+  if (descriptor.type === ResourceType.Api) {
+    const { apiRevision, isCurrent, ...rest } = overrideProperties;
+    if (apiRevision !== undefined || isCurrent !== undefined) {
+      logger.warn(
+        `Ignoring 'apiRevision' and/or 'isCurrent' in API override for '${resourceName}'; ` +
+        `these fields cannot be overridden (matching Toolkit behavior).`
+      );
+    }
+    overrideProperties = rest;
+    if (Object.keys(overrideProperties).length === 0) {
+      return { ...json };
+    }
+  }
+
+  const wrappedOverride = { properties: overrideProperties };
   const result = deepMerge(json, wrappedOverride);
 
   logger.debug(
@@ -129,7 +149,10 @@ function applyFromSection(
 
 /**
  * Apply nested child override (e.g., ApiDiagnostic under apis.children.diagnostics).
- * nameParts layout: [parentName, childName, ...]
+ *
+ * nameParts layout varies by resource type:
+ * - Named children (ApiDiagnostic, ApiOperation, ApiRelease): [parentName, childName]
+ * - Singleton children (ApiPolicy, ProductPolicy): [parentName] (child name is always "policy")
  */
 function applyNestedOverride(
   descriptor: ResourceDescriptor,
@@ -149,8 +172,11 @@ function applyNestedOverride(
   const childSection = parentEntry.children[mapping.childKey];
   if (!childSection) return { ...json };
 
-  // Child name is the second name part (e.g., the diagnostic name, operation name)
-  const childName = descriptor.nameParts[1];
+  // For singleton children (e.g., ApiPolicy), the name is fixed (e.g., "policy"),
+  // NOT in nameParts. For named children, it's nameParts[1].
+  const childName = isSingletonType(descriptor.type)
+    ? getSingletonName(descriptor.type)
+    : descriptor.nameParts[1];
   if (!childName) return { ...json };
 
   const childEntry = findEntryByName(childSection, childName);
@@ -171,8 +197,10 @@ function applyNestedOverride(
 
 /**
  * Apply grandchild (3-level) override.
- * E.g., ApiOperationPolicy: apis[apiName].children.operations[opName].children.policies[policyName]
- * nameParts layout: [parentName, childName, grandchildName]
+ * E.g., ApiOperationPolicy: apis[apiName].children.operations[opName].children.policies[policy]
+ *
+ * nameParts layout for ApiOperationPolicy: [apiName, operationName]
+ * The grandchild name is always the fixed singleton name (e.g., "policy").
  */
 function applyGrandchildOverride(
   descriptor: ResourceDescriptor,
@@ -201,7 +229,8 @@ function applyGrandchildOverride(
   const grandchildSection = childEntry.children[mapping.grandchildKey];
   if (!grandchildSection) return { ...json };
 
-  const grandchildName = descriptor.nameParts[2];
+  // Grandchild is always a singleton (e.g., "policy") — name is NOT in nameParts
+  const grandchildName = getSingletonName(descriptor.type);
   if (!grandchildName) return { ...json };
 
   const grandchildEntry = findEntryByName(grandchildSection, grandchildName);
@@ -218,6 +247,37 @@ function applyGrandchildOverride(
   );
 
   return result;
+}
+
+/**
+ * Get the resource name for override lookup, handling singletons correctly.
+ * - Top-level singletons (ServicePolicy with nameParts: []) use the fixed singleton name
+ * - Named resources use the last element of nameParts
+ */
+function getSingletonOrNamePartName(descriptor: ResourceDescriptor): string {
+  if (descriptor.nameParts.length === 0) {
+    // Top-level singleton (e.g., ServicePolicy)
+    const name = getSingletonName(descriptor.type);
+    if (!name) {
+      throw new RangeError(
+        `getSingletonOrNamePartName: ${descriptor.type} has empty nameParts ` +
+        `but no known singleton name`
+      );
+    }
+    return name;
+  }
+  return getNameFromNameParts(descriptor.nameParts);
+}
+
+/**
+ * Get the fixed singleton name for a resource type from its ARM path.
+ * E.g., ServicePolicy → "policy", ApiPolicy → "policy", ApiWiki → "default"
+ * Returns undefined if the resource type is not a singleton.
+ */
+function getSingletonName(type: ResourceType): string | undefined {
+  if (!isSingletonType(type)) return undefined;
+  const meta = RESOURCE_TYPE_METADATA[type];
+  return meta.armPathSuffix.split('/').pop();
 }
 
 /**

--- a/src/services/override-merger.ts
+++ b/src/services/override-merger.ts
@@ -3,25 +3,66 @@
 /**
  * T033: Override merger service
  * Apply environment-specific overrides from OverrideConfig to resource JSON payloads.
- * Deep-merges with case-insensitive key matching; warns on unknown override keys.
+ * Deep-merges with case-insensitive key matching; supports nested sub-resource overrides.
+ * Handles all Toolkit override sections with generic property passthrough.
  */
 
 import { ResourceDescriptor } from '../models/types.js';
 import { ResourceType } from '../models/resource-types.js';
-import { OverrideConfig } from '../models/config.js';
+import { OverrideConfig, OverrideSection, OverrideEntry } from '../models/config.js';
 import { logger } from '../lib/logger.js';
 import { getNameFromNameParts } from '../lib/resource-path.js';
 
 /**
+ * Map resource types to their top-level override config section key.
+ */
+const OVERRIDE_SECTION_MAP: Partial<Record<ResourceType, keyof OverrideConfig>> = {
+  [ResourceType.NamedValue]: 'namedValues',
+  [ResourceType.Backend]: 'backends',
+  [ResourceType.Api]: 'apis',
+  [ResourceType.Diagnostic]: 'diagnostics',
+  [ResourceType.Logger]: 'loggers',
+  [ResourceType.ServicePolicy]: 'policies',
+  [ResourceType.Gateway]: 'gateways',
+  [ResourceType.VersionSet]: 'versionSets',
+  [ResourceType.Group]: 'groups',
+  [ResourceType.Subscription]: 'subscriptions',
+  [ResourceType.Product]: 'products',
+  [ResourceType.Tag]: 'tags',
+  [ResourceType.PolicyFragment]: 'policyFragments',
+  [ResourceType.Workspace]: 'workspaces',
+};
+
+/**
+ * Map child resource types to their parent section and child key within the parent's children.
+ * Used for nested override lookup (e.g., ApiDiagnostic → apis.children.diagnostics).
+ * `namePartIndex` indicates which name part identifies the child (default: 1).
+ */
+const CHILD_OVERRIDE_MAP: Partial<Record<ResourceType, { parentSection: keyof OverrideConfig; childKey: string; namePartIndex?: number }>> = {
+  [ResourceType.ApiDiagnostic]: { parentSection: 'apis', childKey: 'diagnostics' },
+  [ResourceType.ApiOperation]: { parentSection: 'apis', childKey: 'operations' },
+  [ResourceType.ApiPolicy]: { parentSection: 'apis', childKey: 'policies' },
+  [ResourceType.ApiRelease]: { parentSection: 'apis', childKey: 'releases' },
+  [ResourceType.ProductPolicy]: { parentSection: 'products', childKey: 'policies' },
+};
+
+/**
+ * Map grandchild resource types for 3-level override lookup.
+ * E.g., ApiOperationPolicy → apis.children.operations[op].children.policies[policy]
+ */
+const GRANDCHILD_OVERRIDE_MAP: Partial<Record<ResourceType, {
+  parentSection: keyof OverrideConfig;
+  childKey: string;
+  grandchildKey: string;
+}>> = {
+  [ResourceType.ApiOperationPolicy]: { parentSection: 'apis', childKey: 'operations', grandchildKey: 'policies' },
+};
+
+/**
  * Apply environment overrides from OverrideConfig to a resource JSON payload.
  * Deep-merges matching override properties using case-insensitive key matching.
- * Logs a warning for any override keys that don't match resource type.
+ * Supports both direct overrides and nested sub-resource overrides.
  * Returns a new object (does not mutate input).
- * 
- * @param descriptor - Resource descriptor (type + name identify the resource)
- * @param json - Original resource JSON payload
- * @param overrides - Environment-specific override configuration
- * @returns New JSON object with overrides applied
  */
 export function applyOverrides(
   descriptor: ResourceDescriptor,
@@ -32,63 +73,162 @@ export function applyOverrides(
     return { ...json };
   }
 
-  // Map resource type to override config section
-  const overrideSection = getOverrideSectionForType(descriptor.type, overrides);
-  if (!overrideSection) {
+  // Try direct override lookup first
+  const directSection = OVERRIDE_SECTION_MAP[descriptor.type];
+  if (directSection) {
+    const section = overrides[directSection];
+    if (!section) return { ...json };
+    return applyFromSection(descriptor, json, section);
+  }
+
+  // Try nested child override lookup
+  const childMapping = CHILD_OVERRIDE_MAP[descriptor.type];
+  if (childMapping) {
+    return applyNestedOverride(descriptor, json, overrides, childMapping);
+  }
+
+  // Try grandchild (3-level) override lookup
+  const grandchildMapping = GRANDCHILD_OVERRIDE_MAP[descriptor.type];
+  if (grandchildMapping) {
+    return applyGrandchildOverride(descriptor, json, overrides, grandchildMapping);
+  }
+
+  return { ...json };
+}
+
+/**
+ * Apply override from a direct section match.
+ */
+function applyFromSection(
+  descriptor: ResourceDescriptor,
+  json: Record<string, unknown>,
+  section: OverrideSection
+): Record<string, unknown> {
+  const resourceName = getNameFromNameParts(descriptor.nameParts);
+  const entry = findEntryByName(section, resourceName);
+
+  if (!entry) {
     return { ...json };
   }
 
-  // Find matching override using case-insensitive name comparison
-  const matchingKey = Object.keys(overrideSection).find(
-    (key) => key.toLowerCase() === getNameFromNameParts(descriptor.nameParts).toLowerCase()
-  );
-
-  if (!matchingKey) {
-    return { ...json };
-  }
-
-  const overrideValues = overrideSection[matchingKey];
-  if (overrideValues === null || overrideValues === undefined || typeof overrideValues !== 'object') {
+  if (Object.keys(entry.properties).length === 0) {
     return { ...json };
   }
 
   // ARM resources have all overridable fields inside 'properties'
-  // Wrap the override values inside 'properties' to merge at the correct level
-  const wrappedOverride = { properties: overrideValues };
-
-  // Deep-merge the override into the resource JSON
+  const wrappedOverride = { properties: entry.properties };
   const result = deepMerge(json, wrappedOverride);
 
   logger.debug(
     `Applied overrides to ${descriptor.type} '${descriptor.nameParts.join('/')}'`,
-    { overrideKeys: Object.keys(overrideValues) }
+    { overrideKeys: Object.keys(entry.properties) }
   );
 
   return result;
 }
 
 /**
- * Get the override section for a given resource type.
- * Returns the relevant Record<string, Override> map or undefined.
+ * Apply nested child override (e.g., ApiDiagnostic under apis.children.diagnostics).
+ * nameParts layout: [parentName, childName, ...]
  */
-function getOverrideSectionForType(
-  type: ResourceType,
-  overrides: OverrideConfig
-): Record<string, unknown> | undefined {
-  switch (type) {
-    case ResourceType.NamedValue:
-      return overrides.namedValues;
-    case ResourceType.Backend:
-      return overrides.backends;
-    case ResourceType.Api:
-      return overrides.apis;
-    case ResourceType.Diagnostic:
-      return overrides.diagnostics;
-    case ResourceType.Logger:
-      return overrides.loggers;
-    default:
-      return undefined;
+function applyNestedOverride(
+  descriptor: ResourceDescriptor,
+  json: Record<string, unknown>,
+  overrides: OverrideConfig,
+  mapping: { parentSection: keyof OverrideConfig; childKey: string }
+): Record<string, unknown> {
+  const parentSection = overrides[mapping.parentSection];
+  if (!parentSection) return { ...json };
+
+  const parentName = descriptor.nameParts[0];
+  if (!parentName) return { ...json };
+
+  const parentEntry = findEntryByName(parentSection, parentName);
+  if (!parentEntry?.children) return { ...json };
+
+  const childSection = parentEntry.children[mapping.childKey];
+  if (!childSection) return { ...json };
+
+  // Child name is the second name part (e.g., the diagnostic name, operation name)
+  const childName = descriptor.nameParts[1];
+  if (!childName) return { ...json };
+
+  const childEntry = findEntryByName(childSection, childName);
+  if (!childEntry || Object.keys(childEntry.properties).length === 0) {
+    return { ...json };
   }
+
+  const wrappedOverride = { properties: childEntry.properties };
+  const result = deepMerge(json, wrappedOverride);
+
+  logger.debug(
+    `Applied nested overrides to ${descriptor.type} '${descriptor.nameParts.join('/')}'`,
+    { overrideKeys: Object.keys(childEntry.properties) }
+  );
+
+  return result;
+}
+
+/**
+ * Apply grandchild (3-level) override.
+ * E.g., ApiOperationPolicy: apis[apiName].children.operations[opName].children.policies[policyName]
+ * nameParts layout: [parentName, childName, grandchildName]
+ */
+function applyGrandchildOverride(
+  descriptor: ResourceDescriptor,
+  json: Record<string, unknown>,
+  overrides: OverrideConfig,
+  mapping: { parentSection: keyof OverrideConfig; childKey: string; grandchildKey: string }
+): Record<string, unknown> {
+  const parentSection = overrides[mapping.parentSection];
+  if (!parentSection) return { ...json };
+
+  const parentName = descriptor.nameParts[0];
+  if (!parentName) return { ...json };
+
+  const parentEntry = findEntryByName(parentSection, parentName);
+  if (!parentEntry?.children) return { ...json };
+
+  const childSection = parentEntry.children[mapping.childKey];
+  if (!childSection) return { ...json };
+
+  const childName = descriptor.nameParts[1];
+  if (!childName) return { ...json };
+
+  const childEntry = findEntryByName(childSection, childName);
+  if (!childEntry?.children) return { ...json };
+
+  const grandchildSection = childEntry.children[mapping.grandchildKey];
+  if (!grandchildSection) return { ...json };
+
+  const grandchildName = descriptor.nameParts[2];
+  if (!grandchildName) return { ...json };
+
+  const grandchildEntry = findEntryByName(grandchildSection, grandchildName);
+  if (!grandchildEntry || Object.keys(grandchildEntry.properties).length === 0) {
+    return { ...json };
+  }
+
+  const wrappedOverride = { properties: grandchildEntry.properties };
+  const result = deepMerge(json, wrappedOverride);
+
+  logger.debug(
+    `Applied grandchild overrides to ${descriptor.type} '${descriptor.nameParts.join('/')}'`,
+    { overrideKeys: Object.keys(grandchildEntry.properties) }
+  );
+
+  return result;
+}
+
+/**
+ * Find an override entry by name using case-insensitive matching.
+ */
+function findEntryByName(section: OverrideSection, name: string): OverrideEntry | undefined {
+  const lowerName = name.toLowerCase();
+  const matchingKey = Object.keys(section).find(
+    (key) => key.toLowerCase() === lowerName
+  );
+  return matchingKey ? section[matchingKey] : undefined;
 }
 
 /**
@@ -97,10 +237,6 @@ function getOverrideSectionForType(
  * - Arrays are replaced (not merged)
  * - Primitives from source override target
  * - Returns a new object (immutable)
- * 
- * @param target - Base object
- * @param source - Override object
- * @returns New merged object
  */
 function deepMerge(
   target: Record<string, unknown>,
@@ -111,7 +247,6 @@ function deepMerge(
   for (const [key, sourceValue] of Object.entries(source)) {
     const targetValue = result[key];
 
-    // If both are plain objects, merge recursively
     if (
       isPlainObject(sourceValue) &&
       isPlainObject(targetValue)
@@ -121,7 +256,6 @@ function deepMerge(
         sourceValue as Record<string, unknown>
       );
     } else {
-      // Otherwise replace (arrays, primitives, or type mismatch)
       result[key] = sourceValue;
     }
   }
@@ -129,9 +263,6 @@ function deepMerge(
   return result;
 }
 
-/**
- * Check if a value is a plain object (not an array, null, or other special object).
- */
 function isPlainObject(value: unknown): boolean {
   return (
     typeof value === 'object' &&

--- a/src/services/resource-publisher.ts
+++ b/src/services/resource-publisher.ts
@@ -371,7 +371,10 @@ async function publishPolicy(
       },
     };
 
-    await client.putResource(context, descriptor, payload);
+    // Apply overrides (e.g., format: xml) before PUT — matches Toolkit behavior
+    const mergedPayload = applyOverrides(descriptor, payload, config.overrides);
+
+    await client.putResource(context, descriptor, mergedPayload);
 
     return {
       descriptor,

--- a/src/services/transitive-resolver.ts
+++ b/src/services/transitive-resolver.ts
@@ -160,10 +160,10 @@ function addToFilter(
   dep: TransitiveDependency
 ): boolean {
   const fieldMap: Partial<Record<ResourceType, keyof FilterConfig>> = {
-    [ResourceType.NamedValue]: 'namedValueNames',
-    [ResourceType.Backend]: 'backendNames',
-    [ResourceType.PolicyFragment]: 'policyFragmentNames',
-    [ResourceType.VersionSet]: 'versionSetNames',
+    [ResourceType.NamedValue]: 'namedValues',
+    [ResourceType.Backend]: 'backends',
+    [ResourceType.PolicyFragment]: 'policyFragments',
+    [ResourceType.VersionSet]: 'versionSets',
   };
 
   const field = fieldMap[dep.type];

--- a/src/services/transitive-resolver.ts
+++ b/src/services/transitive-resolver.ts
@@ -159,7 +159,8 @@ function addToFilter(
   filter: FilterConfig,
   dep: TransitiveDependency
 ): boolean {
-  const fieldMap: Partial<Record<ResourceType, keyof FilterConfig>> = {
+  type StringArrayField = 'namedValues' | 'backends' | 'policyFragments' | 'versionSets';
+  const fieldMap: Partial<Record<ResourceType, StringArrayField>> = {
     [ResourceType.NamedValue]: 'namedValues',
     [ResourceType.Backend]: 'backends',
     [ResourceType.PolicyFragment]: 'policyFragments',
@@ -179,7 +180,7 @@ function addToFilter(
 
   // Check if already included (case-insensitive)
   const lowerName = dep.name.toLowerCase();
-  if (current.some((n) => n.toLowerCase() === lowerName)) {
+  if (current.some((n: string) => n.toLowerCase() === lowerName)) {
     return false;
   }
 

--- a/src/services/workspace-extractor.ts
+++ b/src/services/workspace-extractor.ts
@@ -49,9 +49,17 @@ export async function extractWorkspaces(
 ): Promise<WorkspaceExtractionResult[]> {
   const results: WorkspaceExtractionResult[] = [];
   let workspaceNames: string[];
-  if (filter?.workspaces && filter.workspaces.length > 0) {
+
+  if (filter?.workspaces !== undefined) {
+    // Defined workspace filter: use exactly the specified list.
+    // Empty array = exclude all workspaces (extract none).
+    if (filter.workspaces.length === 0) {
+      logger.debug('Workspace filter is empty array — excluding all workspaces');
+      return results;
+    }
     workspaceNames = filter.workspaces;
   } else {
+    // No workspace filter defined — discover all workspaces
     const discovered: string[] = [];
     for await (const item of client.listResources(context, ResourceType.Workspace)) {
       const name = item['name'];

--- a/src/services/workspace-extractor.ts
+++ b/src/services/workspace-extractor.ts
@@ -49,8 +49,8 @@ export async function extractWorkspaces(
 ): Promise<WorkspaceExtractionResult[]> {
   const results: WorkspaceExtractionResult[] = [];
   let workspaceNames: string[];
-  if (filter?.workspaceNames && filter.workspaceNames.length > 0) {
-    workspaceNames = filter.workspaceNames;
+  if (filter?.workspaces && filter.workspaces.length > 0) {
+    workspaceNames = filter.workspaces;
   } else {
     const discovered: string[] = [];
     for await (const item of client.listResources(context, ResourceType.Workspace)) {

--- a/src/templates/azure-devops/extract-pipeline.ts
+++ b/src/templates/azure-devops/extract-pipeline.ts
@@ -21,7 +21,7 @@ parameters:
     default: 'Extract All APIs'
     values:
       - 'Extract All APIs'
-      - 'configuration.extract.yaml'
+      - 'configuration.extractor.yaml'
   - name: resourceGroup
     type: string
     displayName: 'Azure Resource Group'
@@ -72,7 +72,7 @@ steps:
           --resource-group \${{ parameters.resourceGroup }} \\
           --service-name \${{ parameters.serviceName }} \\
           --output ${config.artifactDir} \\
-          --filter configuration.extract.yaml \\
+          --filter configuration.extractor.yaml \\
           --subscription-id $(AZURE_SUBSCRIPTION_ID)
 
   - task: PublishPipelineArtifact@1

--- a/src/templates/configs/filter-config.ts
+++ b/src/templates/configs/filter-config.ts
@@ -14,6 +14,19 @@ export function generateFilterConfig(): string {
 #   - echo-api
 #   - petstore-api
 
+# Advanced: Filter API sub-resources (operations, diagnostics, schemas, releases)
+# apis:
+#   - echo-api                        # Include all sub-resources
+#   - petstore-api:                   # Control sub-resources
+#       operations:
+#         - get-pets
+#         - create-pet
+#       diagnostics:
+#         - applicationinsights
+#       schemas: []                   # Exclude all schemas
+#       releases:
+#         - v1
+
 # Extract only specific products
 # products:
 #   - starter
@@ -79,6 +92,17 @@ export function generateFilterConfig(): string {
 # Extract only specific workspaces
 # workspaces:
 #   - dev-workspace
+
+# Advanced: Filter workspace sub-resources
+# workspaces:
+#   - team-workspace:
+#       apis:
+#         - team-api-1
+#         - team-api-2
+#       backends:
+#         - team-backend
+#       namedValues:
+#         - team-api-key
 
 # Filter behavior:
 # - Leave a section commented out to include ALL resources of that type

--- a/src/templates/configs/filter-config.ts
+++ b/src/templates/configs/filter-config.ts
@@ -81,6 +81,10 @@ export function generateFilterConfig(): string {
 # schemas:
 #   - pet-schema
 
+# Filter service-level policies
+# policies:
+#   - policy
+
 # Extract only specific policy restrictions
 # policyRestrictions:
 #   - global-policy-restriction

--- a/src/templates/configs/filter-config.ts
+++ b/src/templates/configs/filter-config.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 /**
  * T047: Sample filter configuration template
- * Generates a sample configuration.extract.yaml file
+ * Generates a sample configuration.extractor.yaml file
  */
 
 export function generateFilterConfig(): string {
@@ -10,81 +10,81 @@ export function generateFilterConfig(): string {
 # Customize this file to control which resources are extracted
 
 # Extract only specific APIs by name
-# apiNames:
+# apis:
 #   - echo-api
 #   - petstore-api
 
 # Extract only specific products
-# productNames:
+# products:
 #   - starter
 #   - unlimited
 
 # Extract only specific backends
-# backendNames:
+# backends:
 #   - backend-api
 #   - legacy-backend
 
 # Extract only specific named values
-# namedValueNames:
+# namedValues:
 #   - api-key
 #   - connection-string
 
 # Extract only specific loggers
-# loggerNames:
+# loggers:
 #   - appinsights-logger
 
 # Extract only specific diagnostics
-# diagnosticNames:
+# diagnostics:
 #   - applicationinsights
 
 # Extract only specific tags
-# tagNames:
+# tags:
 #   - production
 #   - external
 
 # Extract only specific policy fragments
-# policyFragmentNames:
+# policyFragments:
 #   - rate-limit-fragment
 #   - cors-fragment
 
 # Extract only specific gateways
-# gatewayNames:
+# gateways:
 #   - default
 #   - internal-gateway
 
 # Extract only specific version sets
-# versionSetNames:
+# versionSets:
 #   - payments-v1
 
 # Extract only specific groups
-# groupNames:
+# groups:
 #   - administrators
 
 # Extract only specific subscriptions
-# subscriptionNames:
+# subscriptions:
 #   - starter-subscription
 
 # Extract only specific schemas
-# schemaNames:
+# schemas:
 #   - pet-schema
 
 # Extract only specific policy restrictions
-# policyRestrictionNames:
+# policyRestrictions:
 #   - global-policy-restriction
 
 # Extract only specific documentations
-# documentationNames:
+# documentations:
 #   - getting-started
 
 # Extract only specific workspaces
-# workspaceNames:
+# workspaces:
 #   - dev-workspace
 
 # Filter behavior:
 # - Leave a section commented out to include ALL resources of that type
 # - Set a section to an empty array ([]) to exclude ALL resources of that type
 #   Example:
-#   gatewayNames: []
-#   subscriptionNames: []
+#   gateways: []
+#   subscriptions: []
 `;
 }

--- a/src/templates/configs/override-config.ts
+++ b/src/templates/configs/override-config.ts
@@ -8,6 +8,7 @@
 export function generateOverrideConfig(environment: string): string {
   return `# APIM Override Configuration for ${environment} environment
 # Customize resource properties for this specific environment
+# All APIOps Toolkit override sections are supported.
 
 # Override named values (e.g., API keys, connection strings)
 # namedValues:
@@ -31,8 +32,9 @@ export function generateOverrideConfig(environment: string): string {
 #   - name: legacy-backend
 #     properties:
 #       url: "https://${environment}-legacy.example.com"
+#       resourceId: "/subscriptions/.../sites/${environment}-backend"
 
-# Override API service URLs
+# Override API service URLs (with optional nested sub-resource overrides)
 # apis:
 #   - name: echo-api
 #     properties:
@@ -40,17 +42,57 @@ export function generateOverrideConfig(environment: string): string {
 #   - name: petstore-api
 #     properties:
 #       serviceUrl: "https://${environment}-petstore.example.com"
+#       displayName: "Petstore API (${environment})"
+#     diagnostics:
+#       - name: applicationinsights
+#         properties:
+#           loggerId: "appinsights-logger-${environment}"
+#           verbosity: Error
+#     policies:
+#       - name: policy
+#         properties:
+#           format: rawxml
 
 # Override diagnostic logger references
 # diagnostics:
 #   - name: applicationinsights
 #     properties:
 #       loggerId: "appinsights-logger-${environment}"
+#       verbosity: Error
 
 # Override logger credentials or resource IDs
 # loggers:
 #   - name: appinsights-logger
 #     properties:
+#       loggerType: applicationInsights
 #       resourceId: "/subscriptions/xxxxx/resourceGroups/${environment}-rg/providers/microsoft.insights/components/${environment}-appinsights"
+#       isBuffered: true
+
+# Override service-level policies
+# policies:
+#   - name: policy
+#     properties:
+#       format: rawxml
+
+# Override gateway properties
+# gateways:
+#   - name: on-prem-gateway
+#     properties:
+#       locationData:
+#         name: "${environment} datacenter"
+
+# Override version sets, groups, subscriptions, products, tags, policy fragments
+# versionSets:
+#   - name: my-version-set
+#     properties:
+#       displayName: "My Version Set (${environment})"
+# products:
+#   - name: starter
+#     properties:
+#       displayName: "Starter Plan (${environment})"
+# tags:
+#   - name: env-tag
+#     properties:
+#       displayName: "${environment}"
 `;
 }

--- a/src/templates/github-actions/extract-workflow.ts
+++ b/src/templates/github-actions/extract-workflow.ts
@@ -29,7 +29,7 @@ on:
         type: choice
         options:
           - Extract All APIs
-          - configuration.extract.yaml
+          - configuration.extractor.yaml
 
 permissions:
   id-token: write
@@ -96,7 +96,7 @@ jobs:
             --resource-group \${{ env.APIM_RESOURCE_GROUP }} \\
             --service-name \${{ env.APIM_SERVICE_NAME }} \\
             --output ${config.artifactDir} \\
-            --filter configuration.extract.yaml
+            --filter configuration.extractor.yaml
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/tests/unit/clients/artifact-store.test.ts
+++ b/tests/unit/clients/artifact-store.test.ts
@@ -275,17 +275,17 @@ describe('ArtifactStore', () => {
       const result = await store.listResources(tmpDir);
       expect(result.length).toBeGreaterThanOrEqual(3);
 
-      const apiNames = result
+      const apis = result
         .filter((d) => d.type === ResourceType.Api)
         .map((d) => d.nameParts[0])
         .sort();
-      expect(apiNames).toContain('api1');
-      expect(apiNames).toContain('api2');
+      expect(apis).toContain('api1');
+      expect(apis).toContain('api2');
 
-      const productNames = result
+      const products = result
         .filter((d) => d.type === ResourceType.Product)
         .map((d) => d.nameParts[0]);
-      expect(productNames).toContain('prod1');
+      expect(products).toContain('prod1');
     });
   });
 

--- a/tests/unit/lib/config-loader.test.ts
+++ b/tests/unit/lib/config-loader.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { loadFilterConfig, loadOverrideConfig, loadOTelConfig } from '../../../src/lib/config-loader.js';
+import { logger } from '../../../src/lib/logger.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -14,6 +15,7 @@ describe('config-loader', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -175,6 +177,68 @@ versionSets:
       expect(config!.backends).toEqual(['backend1']);
       expect(config!.versionSets).toEqual(['vs1']);
     });
+
+    it('should load nested API filter entries', async () => {
+      const content = `
+apis:
+  - simple-api
+  - complex-api:
+      operations:
+        - get-pets
+      diagnostics: []
+`;
+      const filePath = path.join(tmpDir, 'nested-api-filter.yaml');
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      const config = await loadFilterConfig(filePath);
+      expect(config).toBeDefined();
+      expect(config!.apis).toEqual(['simple-api', 'complex-api']);
+      expect(config!.apiSubFilters).toEqual({
+        'complex-api': {
+          operations: ['get-pets'],
+          diagnostics: [],
+        },
+      });
+    });
+
+    it('should load nested workspace filter entries', async () => {
+      const content = `
+workspaces:
+  - ws-simple
+  - ws-complex:
+      apis:
+        - api-a
+      diagnostics: []
+`;
+      const filePath = path.join(tmpDir, 'nested-workspace-filter.yaml');
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      const config = await loadFilterConfig(filePath);
+      expect(config).toBeDefined();
+      expect(config!.workspaces).toEqual(['ws-simple', 'ws-complex']);
+      expect(config!.workspaceSubFilters).toEqual({
+        'ws-complex': {
+          apis: ['api-a'],
+          diagnostics: [],
+        },
+      });
+    });
+
+    it('should warn about unknown top-level filter keys', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const content = `
+apis:
+  - api1
+mystery:
+  - value
+`;
+      const filePath = path.join(tmpDir, 'unknown-filter-key.yaml');
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      const config = await loadFilterConfig(filePath);
+      expect(config!.apis).toEqual(['api1']);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown filter config key 'mystery'"));
+    });
   });
 
   describe('loadOverrideConfig', () => {
@@ -239,12 +303,16 @@ backends:
       expect(config).toBeDefined();
       expect(config!.namedValues).toEqual({
         nv1: {
-          value: 'overridden',
+          properties: {
+            value: 'overridden',
+          },
         },
       });
       expect(config!.backends).toEqual({
         be1: {
-          url: 'https://new-backend.com',
+          properties: {
+            url: 'https://new-backend.com',
+          },
         },
       });
     });
@@ -297,7 +365,9 @@ namedValues:
       expect(config).toBeDefined();
       expect(config!.namedValues).toEqual({
         nv1: {
-          value: 'inline-value',
+          properties: {
+            value: 'inline-value',
+          },
         },
       });
     });
@@ -337,14 +407,155 @@ backends:
       expect(config).toBeDefined();
       expect(config!.namedValues).toEqual({
         nv1: {
-          value: 'valid',
+          properties: {
+            value: 'valid',
+          },
         },
       });
       expect(config!.backends).toEqual({
         be1: {
-          url: 'https://valid.example.com',
+          properties: {
+            url: 'https://valid.example.com',
+          },
         },
       });
+    });
+
+    it('should load override sections beyond the original core set', async () => {
+      const content = `
+products:
+  - name: starter
+    properties:
+      displayName: "Starter Plus"
+gateways:
+  - name: gw-1
+    properties:
+      description: "Gateway 1"
+tags:
+  - name: tag-a
+    properties:
+      displayName: "Tag A"
+policies:
+  - name: policy
+    properties:
+      format: "rawxml"
+policyFragments:
+  - name: fragment-a
+    properties:
+      format: "rawxml"
+`;
+      const filePath = path.join(tmpDir, 'override-all-sections.yaml');
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      const config = await loadOverrideConfig(filePath);
+      expect(config).toBeDefined();
+      expect(config!.products).toEqual({
+        starter: {
+          properties: {
+            displayName: 'Starter Plus',
+          },
+        },
+      });
+      expect(config!.gateways).toEqual({
+        'gw-1': {
+          properties: {
+            description: 'Gateway 1',
+          },
+        },
+      });
+      expect(config!.tags).toEqual({
+        'tag-a': {
+          properties: {
+            displayName: 'Tag A',
+          },
+        },
+      });
+      expect(config!.policies).toEqual({
+        policy: {
+          properties: {
+            format: 'rawxml',
+          },
+        },
+      });
+      expect(config!.policyFragments).toEqual({
+        'fragment-a': {
+          properties: {
+            format: 'rawxml',
+          },
+        },
+      });
+    });
+
+    it('should load nested API overrides with child sections', async () => {
+      const content = `
+apis:
+  - name: my-api
+    properties:
+      serviceUrl: "https://prod.example.com"
+    diagnostics:
+      - name: applicationinsights
+        properties:
+          loggerId: "/new-logger"
+    operations:
+      - name: get-pets
+        properties:
+          method: "GET"
+`;
+      const filePath = path.join(tmpDir, 'override-nested-api.yaml');
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      const config = await loadOverrideConfig(filePath);
+      expect(config).toBeDefined();
+      expect(config!.apis).toEqual({
+        'my-api': {
+          properties: {
+            serviceUrl: 'https://prod.example.com',
+          },
+          children: {
+            diagnostics: {
+              applicationinsights: {
+                properties: {
+                  loggerId: '/new-logger',
+                },
+              },
+            },
+            operations: {
+              'get-pets': {
+                properties: {
+                  method: 'GET',
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should warn when an override section contains duplicate names', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const content = `
+namedValues:
+  - name: nv1
+    properties:
+      value: "first"
+  - name: nv1
+    properties:
+      value: "second"
+`;
+      const filePath = path.join(tmpDir, 'override-duplicate-names.yaml');
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      const config = await loadOverrideConfig(filePath);
+      expect(config!.namedValues).toEqual({
+        nv1: {
+          properties: {
+            value: 'second',
+          },
+        },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Duplicate name 'nv1' in overrides.namedValues")
+      );
     });
   });
 

--- a/tests/unit/lib/config-loader.test.ts
+++ b/tests/unit/lib/config-loader.test.ts
@@ -20,12 +20,12 @@ describe('config-loader', () => {
   describe('loadFilterConfig', () => {
     it('should load a valid filter YAML file', async () => {
       const content = `
-apiNames:
+apis:
   - api1
   - api2
-productNames:
+products:
   - starter
-tagNames:
+tags:
   - v1
 `;
       const filePath = path.join(tmpDir, 'filter.yaml');
@@ -33,9 +33,9 @@ tagNames:
 
       const config = await loadFilterConfig(filePath);
       expect(config).toBeDefined();
-      expect(config!.apiNames).toEqual(['api1', 'api2']);
-      expect(config!.productNames).toEqual(['starter']);
-      expect(config!.tagNames).toEqual(['v1']);
+      expect(config!.apis).toEqual(['api1', 'api2']);
+      expect(config!.products).toEqual(['starter']);
+      expect(config!.tags).toEqual(['v1']);
     });
 
     it('should return undefined for missing file', async () => {
@@ -71,7 +71,7 @@ tagNames:
 
     it('should throw for invalid type (non-array field)', async () => {
       const content = `
-apiNames: "not-an-array"
+apis: "not-an-array"
 `;
       const filePath = path.join(tmpDir, 'bad.yaml');
       await fs.writeFile(filePath, content, 'utf-8');
@@ -81,7 +81,7 @@ apiNames: "not-an-array"
 
     it('should throw for array containing non-strings', async () => {
       const content = `
-apiNames:
+apis:
   - 123
   - true
 `;
@@ -93,30 +93,30 @@ apiNames:
 
     it('should handle all filter fields', async () => {
       const content = `
-apiNames: [a]
-backendNames: [b]
-productNames: [c]
-namedValueNames: [d]
-loggerNames: [e]
-diagnosticNames: [f]
-tagNames: [g]
-policyFragmentNames: [h]
-gatewayNames: [i]
-versionSetNames: [j]
-groupNames: [k]
-subscriptionNames: [l]
-schemaNames: [m]
-policyRestrictionNames: [n]
-documentationNames: [o]
-workspaceNames: [p]
+apis: [a]
+backends: [b]
+products: [c]
+namedValues: [d]
+loggers: [e]
+diagnostics: [f]
+tags: [g]
+policyFragments: [h]
+gateways: [i]
+versionSets: [j]
+groups: [k]
+subscriptions: [l]
+schemas: [m]
+policyRestrictions: [n]
+documentations: [o]
+workspaces: [p]
 `;
       const filePath = path.join(tmpDir, 'all-fields.yaml');
       await fs.writeFile(filePath, content, 'utf-8');
 
       const config = await loadFilterConfig(filePath);
       expect(config).toBeDefined();
-      expect(config!.apiNames).toEqual(['a']);
-      expect(config!.workspaceNames).toEqual(['p']);
+      expect(config!.apis).toEqual(['a']);
+      expect(config!.workspaces).toEqual(['p']);
     });
   });
 

--- a/tests/unit/lib/config-loader.test.ts
+++ b/tests/unit/lib/config-loader.test.ts
@@ -118,6 +118,63 @@ workspaces: [p]
       expect(config!.apis).toEqual(['a']);
       expect(config!.workspaces).toEqual(['p']);
     });
+
+    it('should accept legacy *Names keys as aliases', async () => {
+      const content = `
+apiNames:
+  - api1
+  - api2
+productNames:
+  - starter
+backendNames:
+  - backend1
+versionSetNames:
+  - vs1
+`;
+      const filePath = path.join(tmpDir, 'legacy.yaml');
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      const config = await loadFilterConfig(filePath);
+      expect(config).toBeDefined();
+      expect(config!.apis).toEqual(['api1', 'api2']);
+      expect(config!.products).toEqual(['starter']);
+      expect(config!.backends).toEqual(['backend1']);
+      expect(config!.versionSets).toEqual(['vs1']);
+    });
+
+    it('should throw when both Toolkit and legacy keys are used for the same field', async () => {
+      const content = `
+apis:
+  - api1
+apiNames:
+  - api2
+`;
+      const filePath = path.join(tmpDir, 'conflict.yaml');
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      await expect(loadFilterConfig(filePath)).rejects.toThrow(
+        "contains both 'apis' and 'apiNames'"
+      );
+    });
+
+    it('should accept a mix of Toolkit and legacy keys for different fields', async () => {
+      const content = `
+apis:
+  - api1
+backendNames:
+  - backend1
+versionSets:
+  - vs1
+`;
+      const filePath = path.join(tmpDir, 'mixed.yaml');
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      const config = await loadFilterConfig(filePath);
+      expect(config).toBeDefined();
+      expect(config!.apis).toEqual(['api1']);
+      expect(config!.backends).toEqual(['backend1']);
+      expect(config!.versionSets).toEqual(['vs1']);
+    });
   });
 
   describe('loadOverrideConfig', () => {

--- a/tests/unit/services/api-product-extractor.test.ts
+++ b/tests/unit/services/api-product-extractor.test.ts
@@ -727,8 +727,8 @@ describe('api-extractor', () => {
       );
     });
 
-    it('should skip revision that does not match filter apiNames', async () => {
-      const filter: FilterConfig = { apiNames: ['other-api'] };
+    it('should skip revision that does not match filter apis', async () => {
+      const filter: FilterConfig = { apis: ['other-api'] };
       const client = createMockClient({
         listApiRevisions: async function* () {
           yield { apiRevision: '2' };

--- a/tests/unit/services/delete-unmatched-service.test.ts
+++ b/tests/unit/services/delete-unmatched-service.test.ts
@@ -114,11 +114,11 @@ describe('delete-unmatched-service', () => {
 
       const result = await computeDeleteActions(client, store, testContext, testConfig);
 
-      const groupNames = result.filter((d) => d.type === ResourceType.Group).map((d) => d.nameParts[0]);
-      expect(groupNames).not.toContain('administrators');
-      expect(groupNames).not.toContain('developers');
-      expect(groupNames).not.toContain('guests');
-      expect(groupNames).toContain('custom-group');
+      const groups = result.filter((d) => d.type === ResourceType.Group).map((d) => d.nameParts[0]);
+      expect(groups).not.toContain('administrators');
+      expect(groups).not.toContain('developers');
+      expect(groups).not.toContain('guests');
+      expect(groups).toContain('custom-group');
     });
 
     it('should skip system products', async () => {
@@ -136,11 +136,11 @@ describe('delete-unmatched-service', () => {
 
       const result = await computeDeleteActions(client, store, testContext, testConfig);
 
-      const productNames = result.filter((d) => d.type === ResourceType.Product).map((d) => d.nameParts[0]);
-      expect(productNames).not.toContain('master');
-      expect(productNames).not.toContain('unlimited');
-      expect(productNames).not.toContain('starter');
-      expect(productNames).toContain('custom-product');
+      const products = result.filter((d) => d.type === ResourceType.Product).map((d) => d.nameParts[0]);
+      expect(products).not.toContain('master');
+      expect(products).not.toContain('unlimited');
+      expect(products).not.toContain('starter');
+      expect(products).toContain('custom-product');
     });
 
     it('should skip echo-api system API', async () => {
@@ -156,9 +156,9 @@ describe('delete-unmatched-service', () => {
 
       const result = await computeDeleteActions(client, store, testContext, testConfig);
 
-      const apiNames = result.filter((d) => d.type === ResourceType.Api).map((d) => d.nameParts[0]);
-      expect(apiNames).not.toContain('echo-api');
-      expect(apiNames).toContain('custom-api');
+      const apis = result.filter((d) => d.type === ResourceType.Api).map((d) => d.nameParts[0]);
+      expect(apis).not.toContain('echo-api');
+      expect(apis).toContain('custom-api');
     });
 
     it('should handle empty artifact store (nothing to delete)', async () => {

--- a/tests/unit/services/extract-service.test.ts
+++ b/tests/unit/services/extract-service.test.ts
@@ -105,7 +105,7 @@ describe('extract-service', () => {
       });
       const store = createMockStore();
 
-      const filter: FilterConfig = { namedValueNames: ['nv-keep'] };
+      const filter: FilterConfig = { namedValues: ['nv-keep'] };
       const config: ExtractConfig = {
         service: testContext,
         outputDir: '/output',
@@ -381,7 +381,7 @@ describe('extract-service', () => {
         service: testContext,
         outputDir: '/output',
         includeTransitive: true,
-        filter: { apiNames: [] }, // Trigger transitive resolution
+        filter: { apis: [] }, // Trigger transitive resolution
         logLevel: LogLevel.INFO,
       };
 
@@ -404,7 +404,7 @@ describe('extract-service', () => {
         service: testContext,
         outputDir: '/output',
         includeTransitive: true,
-        filter: { apiNames: [] },
+        filter: { apis: [] },
         logLevel: LogLevel.INFO,
       };
 

--- a/tests/unit/services/filter-service.test.ts
+++ b/tests/unit/services/filter-service.test.ts
@@ -26,7 +26,7 @@ describe('filter-service', () => {
     });
 
     it('should include resources when filter field is undefined', () => {
-      const filter: FilterConfig = { productNames: ['my-product'] };
+      const filter: FilterConfig = { products: ['my-product'] };
       const descriptor: ResourceDescriptor = {
         type: ResourceType.Api,
         nameParts: ['my-api'],
@@ -35,7 +35,7 @@ describe('filter-service', () => {
     });
 
     it('should exclude all resources when filter field is empty array', () => {
-      const filter: FilterConfig = { apiNames: [] };
+      const filter: FilterConfig = { apis: [] };
       const descriptor: ResourceDescriptor = {
         type: ResourceType.Api,
         nameParts: ['my-api'],
@@ -44,7 +44,7 @@ describe('filter-service', () => {
     });
 
     it('should include matching resources (case-insensitive)', () => {
-      const filter: FilterConfig = { apiNames: ['My-Api'] };
+      const filter: FilterConfig = { apis: ['My-Api'] };
       const descriptor: ResourceDescriptor = {
         type: ResourceType.Api,
         nameParts: ['my-api'],
@@ -53,7 +53,7 @@ describe('filter-service', () => {
     });
 
     it('should exclude non-matching resources', () => {
-      const filter: FilterConfig = { apiNames: ['other-api'] };
+      const filter: FilterConfig = { apis: ['other-api'] };
       const descriptor: ResourceDescriptor = {
         type: ResourceType.Api,
         nameParts: ['my-api'],
@@ -62,7 +62,7 @@ describe('filter-service', () => {
     });
 
     it('should match API revisions by root name', () => {
-      const filter: FilterConfig = { apiNames: ['my-api'] };
+      const filter: FilterConfig = { apis: ['my-api'] };
       const descriptor: ResourceDescriptor = {
         type: ResourceType.Api,
         nameParts: ['my-api;rev=2'],
@@ -71,7 +71,7 @@ describe('filter-service', () => {
     });
 
     it('should filter child resources by parent name', () => {
-      const filter: FilterConfig = { apiNames: ['my-api'] };
+      const filter: FilterConfig = { apis: ['my-api'] };
 
       // ApiPolicy child — nameParts: [apiName]
       const policyDescriptor: ResourceDescriptor = {
@@ -89,7 +89,7 @@ describe('filter-service', () => {
     });
 
     it('should filter grandchild resources by grandparent name', () => {
-      const filter: FilterConfig = { apiNames: ['my-api'] };
+      const filter: FilterConfig = { apis: ['my-api'] };
 
       // ApiOperationPolicy — nameParts: [apiName, opName], filter checks nameParts[0]
       const opPolicy: ResourceDescriptor = {
@@ -106,7 +106,7 @@ describe('filter-service', () => {
     });
 
     it('should filter product children by product name', () => {
-      const filter: FilterConfig = { productNames: ['starter'] };
+      const filter: FilterConfig = { products: ['starter'] };
 
       // ProductPolicy — nameParts: [productName]
       const productPolicy: ResourceDescriptor = {
@@ -124,7 +124,7 @@ describe('filter-service', () => {
 
     it('should filter product children by parent name, not by child name (ProductApi)', () => {
       // nameParts[0] = productName for ProductApi
-      const filter: FilterConfig = { productNames: ['starter'] };
+      const filter: FilterConfig = { products: ['starter'] };
 
       // ProductApi with product='premium' should NOT match filter for 'starter'
       const productApi: ResourceDescriptor = {
@@ -135,7 +135,7 @@ describe('filter-service', () => {
     });
 
     it('should always include ServicePolicy', () => {
-      const filter: FilterConfig = { apiNames: [] };
+      const filter: FilterConfig = { apis: [] };
       const descriptor: ResourceDescriptor = {
         type: ResourceType.ServicePolicy,
         nameParts: [],
@@ -144,7 +144,7 @@ describe('filter-service', () => {
     });
 
     it('should filter named values', () => {
-      const filter: FilterConfig = { namedValueNames: ['my-secret'] };
+      const filter: FilterConfig = { namedValues: ['my-secret'] };
       const included: ResourceDescriptor = {
         type: ResourceType.NamedValue,
         nameParts: ['my-secret'],
@@ -158,7 +158,7 @@ describe('filter-service', () => {
     });
 
     it('should filter backends', () => {
-      const filter: FilterConfig = { backendNames: ['my-backend'] };
+      const filter: FilterConfig = { backends: ['my-backend'] };
       const included: ResourceDescriptor = {
         type: ResourceType.Backend,
         nameParts: ['my-backend'],
@@ -167,7 +167,7 @@ describe('filter-service', () => {
     });
 
     it('should filter gateways', () => {
-      const filter: FilterConfig = { gatewayNames: ['gw-1'] };
+      const filter: FilterConfig = { gateways: ['gw-1'] };
       const included: ResourceDescriptor = {
         type: ResourceType.Gateway,
         nameParts: ['gw-1'],
@@ -176,7 +176,7 @@ describe('filter-service', () => {
     });
 
     it('should filter gateway children by gateway name', () => {
-      const filter: FilterConfig = { gatewayNames: ['gw-1'] };
+      const filter: FilterConfig = { gateways: ['gw-1'] };
       const gwApi: ResourceDescriptor = {
         type: ResourceType.GatewayApi,
         nameParts: ['gw-1', 'my-api'], // nameParts[0]=gatewayName, nameParts[1]=apiName
@@ -201,7 +201,7 @@ describe('filter-service', () => {
     });
 
     it('should filter resources based on config', () => {
-      const filter: FilterConfig = { apiNames: ['api-1'] };
+      const filter: FilterConfig = { apis: ['api-1'] };
       const descriptors: ResourceDescriptor[] = [
         { type: ResourceType.Api, nameParts: ['api-1'] },
         { type: ResourceType.Api, nameParts: ['api-2'] },

--- a/tests/unit/services/filter-service.test.ts
+++ b/tests/unit/services/filter-service.test.ts
@@ -189,6 +189,89 @@ describe('filter-service', () => {
       };
       expect(shouldIncludeResource(otherGwApi, filter)).toBe(false);
     });
+
+    it('should include API operations listed in apiSubFilters', () => {
+      const filter: FilterConfig = {
+        apis: ['my-api'],
+        apiSubFilters: {
+          'my-api': {
+            operations: ['get-pets'],
+          },
+        },
+      };
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ApiOperation,
+        nameParts: ['my-api', 'get-pets'],
+      };
+
+      expect(shouldIncludeResource(descriptor, filter)).toBe(true);
+    });
+
+    it('should exclude API operations when operation sub-filter is empty', () => {
+      const filter: FilterConfig = {
+        apis: ['my-api'],
+        apiSubFilters: {
+          'my-api': {
+            operations: [],
+          },
+        },
+      };
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ApiOperation,
+        nameParts: ['my-api', 'get-pets'],
+      };
+
+      expect(shouldIncludeResource(descriptor, filter)).toBe(false);
+    });
+
+    it('should include API diagnostics when no diagnostic sub-filter is specified', () => {
+      const filter: FilterConfig = {
+        apis: ['my-api'],
+        apiSubFilters: {
+          'my-api': {
+            operations: ['get-pets'],
+          },
+        },
+      };
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ApiDiagnostic,
+        nameParts: ['my-api', 'applicationinsights'],
+      };
+
+      expect(shouldIncludeResource(descriptor, filter)).toBe(true);
+    });
+
+    it('should exclude API schemas when schema sub-filter is empty', () => {
+      const filter: FilterConfig = {
+        apis: ['my-api'],
+        apiSubFilters: {
+          'my-api': {
+            schemas: [],
+          },
+        },
+      };
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ApiSchema,
+        nameParts: ['my-api', 'pet-schema'],
+      };
+
+      expect(shouldIncludeResource(descriptor, filter)).toBe(false);
+    });
+
+    it('should filter workspaces', () => {
+      const filter: FilterConfig = { workspaces: ['workspace-a'] };
+      const included: ResourceDescriptor = {
+        type: ResourceType.Workspace,
+        nameParts: ['workspace-a'],
+      };
+      const excluded: ResourceDescriptor = {
+        type: ResourceType.Workspace,
+        nameParts: ['workspace-b'],
+      };
+
+      expect(shouldIncludeResource(included, filter)).toBe(true);
+      expect(shouldIncludeResource(excluded, filter)).toBe(false);
+    });
   });
 
   describe('filterResources', () => {

--- a/tests/unit/services/filter-service.test.ts
+++ b/tests/unit/services/filter-service.test.ts
@@ -134,13 +134,29 @@ describe('filter-service', () => {
       expect(shouldIncludeResource(productApi, filter)).toBe(false);
     });
 
-    it('should always include ServicePolicy', () => {
+    it('should include ServicePolicy when policies filter is undefined', () => {
       const filter: FilterConfig = { apis: [] };
       const descriptor: ResourceDescriptor = {
         type: ResourceType.ServicePolicy,
         nameParts: [],
       };
       expect(shouldIncludeResource(descriptor, filter)).toBe(true);
+    });
+
+    it('should filter ServicePolicy via policies key', () => {
+      // ServicePolicy has nameParts: [] — uses fixed singleton name "policy"
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ServicePolicy,
+        nameParts: [],
+      };
+
+      // Include when listed
+      const includeFilter: FilterConfig = { policies: ['policy'] };
+      expect(shouldIncludeResource(descriptor, includeFilter)).toBe(true);
+
+      // Exclude when empty array
+      const excludeFilter: FilterConfig = { policies: [] };
+      expect(shouldIncludeResource(descriptor, excludeFilter)).toBe(false);
     });
 
     it('should filter named values', () => {

--- a/tests/unit/services/init-service.test.ts
+++ b/tests/unit/services/init-service.test.ts
@@ -138,7 +138,7 @@ describe('init-service', () => {
 
       const result = await initService.run(config);
 
-      expect(result.configs).toContain('configuration.extract.yaml');
+      expect(result.configs).toContain('configuration.extractor.yaml');
     });
 
     it('should generate override configuration for each environment', async () => {
@@ -251,7 +251,7 @@ describe('init-service', () => {
       // Mock file exists for filter config and the CLI tarball
       vi.mocked(fs.access).mockImplementation(async (filePath: PathLike) => {
         const p = filePath.toString();
-        if (p === TEST_CLI_PACKAGE_RESOLVED || p.includes('configuration.extract.yaml')) {
+        if (p === TEST_CLI_PACKAGE_RESOLVED || p.includes('configuration.extractor.yaml')) {
           return Promise.resolve();
         }
         throw new Error('ENOENT');
@@ -276,7 +276,7 @@ describe('init-service', () => {
       // Mock file exists for filter config and the CLI tarball
       vi.mocked(fs.access).mockImplementation(async (filePath: PathLike) => {
         const p = filePath.toString();
-        if (p === TEST_CLI_PACKAGE_RESOLVED || p.includes('configuration.extract.yaml')) {
+        if (p === TEST_CLI_PACKAGE_RESOLVED || p.includes('configuration.extractor.yaml')) {
           return Promise.resolve();
         }
         throw new Error('ENOENT');

--- a/tests/unit/services/override-merger.test.ts
+++ b/tests/unit/services/override-merger.test.ts
@@ -41,7 +41,9 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         namedValues: {
           'my-nv': {
-            value: 'overridden-value',
+            properties: {
+              value: 'overridden-value',
+            },
           },
         },
       };
@@ -55,7 +57,9 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         namedValues: {
           'MY-NV': {
-            value: 'case-insensitive-match',
+            properties: {
+              value: 'case-insensitive-match',
+            },
           },
         },
       };
@@ -81,7 +85,9 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         backends: {
           'my-backend': {
-            url: 'https://overridden.example.com',
+            properties: {
+              url: 'https://overridden.example.com',
+            },
           },
         },
       };
@@ -108,7 +114,9 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         apis: {
           'my-api': {
-            serviceUrl: 'https://overridden-api.example.com',
+            properties: {
+              serviceUrl: 'https://overridden-api.example.com',
+            },
           },
         },
       };
@@ -122,8 +130,10 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         namedValues: {
           'my-nv': {
-            keyVault: {
-              secretIdentifier: 'https://vault.azure.net/secrets/my-secret',
+            properties: {
+              keyVault: {
+                secretIdentifier: 'https://vault.azure.net/secrets/my-secret',
+              },
             },
           },
         },
@@ -152,7 +162,9 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         namedValues: {
           'my-nv': {
-            value: 'new-value',
+            properties: {
+              value: 'new-value',
+            },
           },
         },
       };
@@ -177,7 +189,9 @@ describe('override-merger', () => {
 
       const overrideConfig: OverrideConfig = {
         namedValues: {
-          'some-nv': { value: 'test' },
+          'some-nv': {
+            properties: { value: 'test' },
+          },
         },
       };
 
@@ -189,7 +203,9 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         namedValues: {
           'other-nv': {
-            value: 'other-value',
+            properties: {
+              value: 'other-value',
+            },
           },
         },
       };
@@ -202,7 +218,9 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         namedValues: {
           'my-nv': {
-            tags: ['env:prod', 'region:us'],
+            properties: {
+              tags: ['env:prod', 'region:us'],
+            },
           },
         },
       };
@@ -223,7 +241,9 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         namedValues: {
           'my-nv': {
-            displayName: 'New Display Name',
+            properties: {
+              displayName: 'New Display Name',
+            },
           },
         },
       };
@@ -249,13 +269,246 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         loggers: {
           'my-logger': {
-            resourceId: '/subscriptions/new/...',
+            properties: {
+              resourceId: '/subscriptions/new/...',
+            },
           },
         },
       };
 
       const result = applyOverrides(loggerDescriptor, loggerJson, overrideConfig);
       expect(result.properties).toHaveProperty('resourceId', '/subscriptions/new/...');
+    });
+
+    it('should apply nested API diagnostic overrides', () => {
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ApiDiagnostic,
+        nameParts: ['my-api', 'applicationinsights'],
+      };
+      const json = { name: 'applicationinsights', properties: { loggerId: '/old-logger' } };
+      const overrideConfig: OverrideConfig = {
+        apis: {
+          'my-api': {
+            properties: { serviceUrl: 'https://prod.example.com' },
+            children: {
+              diagnostics: {
+                applicationinsights: {
+                  properties: { loggerId: '/new-logger', verbosity: 'Error' },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = applyOverrides(descriptor, json, overrideConfig);
+      expect(result.properties).toHaveProperty('loggerId', '/new-logger');
+      expect((result.properties as Record<string, unknown>).verbosity).toBe('Error');
+    });
+
+    it('should apply nested API operation overrides', () => {
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ApiOperation,
+        nameParts: ['my-api', 'get-pets'],
+      };
+      const json = {
+        name: 'get-pets',
+        properties: {
+          method: 'GET',
+          urlTemplate: '/pets',
+        },
+      };
+      const overrideConfig: OverrideConfig = {
+        apis: {
+          'my-api': {
+            properties: {},
+            children: {
+              operations: {
+                'get-pets': {
+                  properties: {
+                    method: 'POST',
+                    description: 'Overridden operation',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = applyOverrides(descriptor, json, overrideConfig);
+      expect(result.properties).toHaveProperty('method', 'POST');
+      expect(result.properties).toHaveProperty('urlTemplate', '/pets');
+      expect(result.properties).toHaveProperty('description', 'Overridden operation');
+    });
+
+    it('should apply 3-level ApiOperationPolicy overrides', () => {
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ApiOperationPolicy,
+        nameParts: ['my-api', 'get-pets', 'policy'],
+      };
+      const json = { name: 'policy', properties: { format: 'xml' } };
+      const overrideConfig: OverrideConfig = {
+        apis: {
+          'my-api': {
+            properties: {},
+            children: {
+              operations: {
+                'get-pets': {
+                  properties: {},
+                  children: {
+                    policies: {
+                      policy: {
+                        properties: { format: 'rawxml' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = applyOverrides(descriptor, json, overrideConfig);
+      expect(result.properties).toHaveProperty('format', 'rawxml');
+    });
+
+    it('should apply nested product policy overrides', () => {
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ProductPolicy,
+        nameParts: ['starter', 'policy'],
+      };
+      const json = { name: 'policy', properties: { format: 'xml' } };
+      const overrideConfig: OverrideConfig = {
+        products: {
+          starter: {
+            properties: {},
+            children: {
+              policies: {
+                policy: {
+                  properties: { format: 'rawxml' },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = applyOverrides(descriptor, json, overrideConfig);
+      expect(result.properties).toHaveProperty('format', 'rawxml');
+    });
+
+    it('should not apply sub-resource overrides when parent has no children', () => {
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ApiDiagnostic,
+        nameParts: ['my-api', 'applicationinsights'],
+      };
+      const json = { name: 'applicationinsights', properties: { loggerId: '/old-logger' } };
+      const overrideConfig: OverrideConfig = {
+        apis: {
+          'my-api': {
+            properties: { serviceUrl: 'https://prod.example.com' },
+          },
+        },
+      };
+
+      const result = applyOverrides(descriptor, json, overrideConfig);
+      expect(result).toEqual(json);
+    });
+
+    it('should apply overrides from newly mapped top-level sections', () => {
+      const cases: Array<{
+        descriptor: ResourceDescriptor;
+        json: Record<string, unknown>;
+        overrideConfig: OverrideConfig;
+        expectedKey: string;
+        expectedValue: unknown;
+      }> = [
+        {
+          descriptor: { type: ResourceType.Product, nameParts: ['starter'] },
+          json: { name: 'starter', properties: { displayName: 'Starter' } },
+          overrideConfig: {
+            products: {
+              starter: { properties: { displayName: 'Starter Plus' } },
+            },
+          },
+          expectedKey: 'displayName',
+          expectedValue: 'Starter Plus',
+        },
+        {
+          descriptor: { type: ResourceType.Gateway, nameParts: ['gw-1'] },
+          json: { name: 'gw-1', properties: { description: 'Original gateway' } },
+          overrideConfig: {
+            gateways: {
+              'gw-1': { properties: { description: 'Updated gateway' } },
+            },
+          },
+          expectedKey: 'description',
+          expectedValue: 'Updated gateway',
+        },
+        {
+          descriptor: { type: ResourceType.Tag, nameParts: ['tag-a'] },
+          json: { name: 'tag-a', properties: { displayName: 'Tag A' } },
+          overrideConfig: {
+            tags: {
+              'tag-a': { properties: { displayName: 'Tag Alpha' } },
+            },
+          },
+          expectedKey: 'displayName',
+          expectedValue: 'Tag Alpha',
+        },
+        {
+          descriptor: { type: ResourceType.ServicePolicy, nameParts: ['policy'] },
+          json: { name: 'policy', properties: { format: 'xml' } },
+          overrideConfig: {
+            policies: {
+              policy: { properties: { format: 'rawxml' } },
+            },
+          },
+          expectedKey: 'format',
+          expectedValue: 'rawxml',
+        },
+        {
+          descriptor: { type: ResourceType.PolicyFragment, nameParts: ['fragment-a'] },
+          json: { name: 'fragment-a', properties: { format: 'xml' } },
+          overrideConfig: {
+            policyFragments: {
+              'fragment-a': { properties: { format: 'rawxml' } },
+            },
+          },
+          expectedKey: 'format',
+          expectedValue: 'rawxml',
+        },
+      ];
+
+      for (const testCase of cases) {
+        const result = applyOverrides(testCase.descriptor, testCase.json, testCase.overrideConfig);
+        expect(result.properties).toHaveProperty(testCase.expectedKey, testCase.expectedValue);
+      }
+    });
+
+    it('should match nested override keys case-insensitively', () => {
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ApiDiagnostic,
+        nameParts: ['my-api', 'applicationinsights'],
+      };
+      const json = { name: 'applicationinsights', properties: { loggerId: '/old-logger' } };
+      const overrideConfig: OverrideConfig = {
+        apis: {
+          'MY-API': {
+            properties: {},
+            children: {
+              diagnostics: {
+                ApplicationInsights: {
+                  properties: { loggerId: '/case-insensitive-logger' },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = applyOverrides(descriptor, json, overrideConfig);
+      expect(result.properties).toHaveProperty('loggerId', '/case-insensitive-logger');
     });
 
     it('should apply diagnostic overrides', () => {
@@ -274,7 +527,9 @@ describe('override-merger', () => {
       const overrideConfig: OverrideConfig = {
         diagnostics: {
           'my-diagnostic': {
-            loggerId: '/loggers/new-logger',
+            properties: {
+              loggerId: '/loggers/new-logger',
+            },
           },
         },
       };

--- a/tests/unit/services/override-merger.test.ts
+++ b/tests/unit/services/override-merger.test.ts
@@ -342,9 +342,11 @@ describe('override-merger', () => {
     });
 
     it('should apply 3-level ApiOperationPolicy overrides', () => {
+      // ApiOperationPolicy is a singleton child — nameParts: [apiName, operationName]
+      // The policy name "policy" is fixed and NOT in nameParts
       const descriptor: ResourceDescriptor = {
         type: ResourceType.ApiOperationPolicy,
-        nameParts: ['my-api', 'get-pets', 'policy'],
+        nameParts: ['my-api', 'get-pets'],
       };
       const json = { name: 'policy', properties: { format: 'xml' } };
       const overrideConfig: OverrideConfig = {
@@ -373,9 +375,11 @@ describe('override-merger', () => {
     });
 
     it('should apply nested product policy overrides', () => {
+      // ProductPolicy is a singleton child — nameParts: [productName]
+      // The policy name "policy" is fixed and NOT in nameParts
       const descriptor: ResourceDescriptor = {
         type: ResourceType.ProductPolicy,
-        nameParts: ['starter', 'policy'],
+        nameParts: ['starter'],
       };
       const json = { name: 'policy', properties: { format: 'xml' } };
       const overrideConfig: OverrideConfig = {
@@ -457,7 +461,8 @@ describe('override-merger', () => {
           expectedValue: 'Tag Alpha',
         },
         {
-          descriptor: { type: ResourceType.ServicePolicy, nameParts: ['policy'] },
+          // ServicePolicy is a top-level singleton — nameParts: []
+          descriptor: { type: ResourceType.ServicePolicy, nameParts: [] },
           json: { name: 'policy', properties: { format: 'xml' } },
           overrideConfig: {
             policies: {
@@ -536,6 +541,73 @@ describe('override-merger', () => {
 
       const result = applyOverrides(diagnosticDescriptor, diagnosticJson, overrideConfig);
       expect(result.properties).toHaveProperty('loggerId', '/loggers/new-logger');
+    });
+
+    it('should apply ServicePolicy override with empty nameParts', () => {
+      // ServicePolicy is a top-level singleton with nameParts: [] (verified from buildDescriptor)
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ServicePolicy,
+        nameParts: [],
+      };
+      const json = { name: 'policy', properties: { format: 'xml', value: '<policies/>' } };
+      const overrideConfig: OverrideConfig = {
+        policies: {
+          policy: { properties: { format: 'rawxml' } },
+        },
+      };
+      const result = applyOverrides(descriptor, json, overrideConfig);
+      expect(result.properties).toHaveProperty('format', 'rawxml');
+      expect(result.properties).toHaveProperty('value', '<policies/>');
+    });
+
+    it('should apply ApiPolicy override with singleton nameParts', () => {
+      // ApiPolicy is a singleton child with nameParts: [apiName] (verified from buildDescriptor)
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.ApiPolicy,
+        nameParts: ['my-api'],
+      };
+      const json = { name: 'policy', properties: { format: 'xml' } };
+      const overrideConfig: OverrideConfig = {
+        apis: {
+          'my-api': {
+            properties: {},
+            children: {
+              policies: {
+                policy: { properties: { format: 'rawxml' } },
+              },
+            },
+          },
+        },
+      };
+      const result = applyOverrides(descriptor, json, overrideConfig);
+      expect(result.properties).toHaveProperty('format', 'rawxml');
+    });
+
+    it('should strip apiRevision and isCurrent from API overrides', () => {
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['my-api'],
+      };
+      const json = {
+        name: 'my-api',
+        properties: { serviceUrl: 'https://dev.example.com', apiRevision: '1', isCurrent: true },
+      };
+      const overrideConfig: OverrideConfig = {
+        apis: {
+          'my-api': {
+            properties: {
+              serviceUrl: 'https://prod.example.com',
+              apiRevision: '99',
+              isCurrent: false,
+            },
+          },
+        },
+      };
+      const result = applyOverrides(descriptor, json, overrideConfig);
+      expect(result.properties).toHaveProperty('serviceUrl', 'https://prod.example.com');
+      // apiRevision and isCurrent should NOT be overridden
+      expect(result.properties).toHaveProperty('apiRevision', '1');
+      expect(result.properties).toHaveProperty('isCurrent', true);
     });
   });
 });

--- a/tests/unit/services/resource-extractor.test.ts
+++ b/tests/unit/services/resource-extractor.test.ts
@@ -93,7 +93,7 @@ describe('resource-extractor', () => {
         { name: 'nv-2', properties: {} },
       ]);
       const store = createMockStore();
-      const filter: FilterConfig = { namedValueNames: ['nv-1'] };
+      const filter: FilterConfig = { namedValues: ['nv-1'] };
 
       const result = await extractResourceType(
         client, store, testContext,

--- a/tests/unit/services/resource-publisher.test.ts
+++ b/tests/unit/services/resource-publisher.test.ts
@@ -29,9 +29,11 @@ function createMockClient() {
     listResources: async function* () {},
     getResource: vi.fn(),
     putResource: vi.fn().mockResolvedValue(undefined),
+    patchResource: vi.fn().mockResolvedValue(undefined),
     deleteResource: vi.fn(),
     listApiRevisions: async function* () {},
     getApiSpecification: vi.fn(),
+    validatePreFlight: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -149,7 +151,9 @@ describe('resource-publisher', () => {
         overrides: {
           namedValues: {
             'my-nv': {
-              value: 'overridden',
+              properties: {
+                value: 'overridden',
+              },
             },
           },
         },

--- a/tests/unit/services/transitive-resolver.test.ts
+++ b/tests/unit/services/transitive-resolver.test.ts
@@ -115,12 +115,12 @@ describe('transitive-resolver', () => {
       const apis = new Map<string, Record<string, unknown>>();
 
       const filter: FilterConfig = {
-        apiNames: ['my-api'],
-        namedValueNames: [], // Start with empty — should be expanded
+        apis: ['my-api'],
+        namedValues: [], // Start with empty — should be expanded
       };
 
       const expanded = resolveTransitiveDependencies(policies, apis, filter);
-      expect(expanded.namedValueNames).toContain('my-secret');
+      expect(expanded.namedValues).toContain('my-secret');
     });
 
     it('should not add to undefined filter fields (unfiltered types)', () => {
@@ -129,14 +129,14 @@ describe('transitive-resolver', () => {
 
       const apis = new Map<string, Record<string, unknown>>();
 
-      // namedValueNames is undefined = all named values included
+      // namedValues is undefined = all named values included
       const filter: FilterConfig = {
-        apiNames: ['my-api'],
+        apis: ['my-api'],
       };
 
       const expanded = resolveTransitiveDependencies(policies, apis, filter);
       // Should remain undefined (no need to add — all are already included)
-      expect(expanded.namedValueNames).toBeUndefined();
+      expect(expanded.namedValues).toBeUndefined();
     });
 
     it('should not duplicate existing entries', () => {
@@ -146,11 +146,11 @@ describe('transitive-resolver', () => {
       const apis = new Map<string, Record<string, unknown>>();
 
       const filter: FilterConfig = {
-        namedValueNames: ['existing-secret'],
+        namedValues: ['existing-secret'],
       };
 
       const expanded = resolveTransitiveDependencies(policies, apis, filter);
-      expect(expanded.namedValueNames).toEqual(['existing-secret']);
+      expect(expanded.namedValues).toEqual(['existing-secret']);
     });
   });
 

--- a/tests/unit/services/workspace-extractor.test.ts
+++ b/tests/unit/services/workspace-extractor.test.ts
@@ -52,7 +52,7 @@ describe('workspace-extractor', () => {
         seenTypes.push(type);
       };
       const store = createMockStore();
-      const filter: FilterConfig = { workspaceNames: ['ws-1'] };
+      const filter: FilterConfig = { workspaces: ['ws-1'] };
 
       await extractWorkspaces(
         client, store, testContext, '/output', filter
@@ -99,7 +99,7 @@ describe('workspace-extractor', () => {
     it('should skip extraction when workspace names array is empty', async () => {
       const client = createMockClient();
       const store = createMockStore();
-      const filter: FilterConfig = { workspaceNames: [] };
+      const filter: FilterConfig = { workspaces: [] };
 
       const results = await extractWorkspaces(
         client, store, testContext, '/output', filter
@@ -117,7 +117,7 @@ describe('workspace-extractor', () => {
         }
       };
       const store = createMockStore();
-      const filter: FilterConfig = { workspaceNames: ['ws-1'] };
+      const filter: FilterConfig = { workspaces: ['ws-1'] };
 
       const results = await extractWorkspaces(
         client, store, testContext, '/output', filter
@@ -132,7 +132,7 @@ describe('workspace-extractor', () => {
       const client = createMockClient();
       client.listResources = async function* () {};
       const store = createMockStore();
-      const filter: FilterConfig = { workspaceNames: ['ws-1', 'ws-2'] };
+      const filter: FilterConfig = { workspaces: ['ws-1', 'ws-2'] };
 
       const results = await extractWorkspaces(
         client, store, testContext, '/output', filter
@@ -150,7 +150,7 @@ describe('workspace-extractor', () => {
         throw new Error('Workspace not found');
       };
       const store = createMockStore();
-      const filter: FilterConfig = { workspaceNames: ['bad-ws'] };
+      const filter: FilterConfig = { workspaces: ['bad-ws'] };
 
       const results = await extractWorkspaces(
         client, store, testContext, '/output', filter
@@ -170,7 +170,7 @@ describe('workspace-extractor', () => {
       };
       client.getResource = vi.fn().mockResolvedValue(undefined);
       const store = createMockStore();
-      const filter: FilterConfig = { workspaceNames: ['ws-1'] };
+      const filter: FilterConfig = { workspaces: ['ws-1'] };
 
       const results = await extractWorkspaces(
         client, store, testContext, '/output', filter
@@ -191,7 +191,7 @@ describe('workspace-extractor', () => {
       };
       client.getResource = vi.fn().mockResolvedValue(undefined);
       const store = createMockStore();
-      const filter: FilterConfig = { workspaceNames: ['ws-1'] };
+      const filter: FilterConfig = { workspaces: ['ws-1'] };
 
       const results = await extractWorkspaces(
         client, store, testContext, '/output', filter

--- a/tests/unit/templates/azure-devops/extract-pipeline.test.ts
+++ b/tests/unit/templates/azure-devops/extract-pipeline.test.ts
@@ -25,7 +25,7 @@ describe('azure-devops/extract-pipeline', () => {
       const pipeline = generateExtractPipeline({ artifactDir: './apim-artifacts' });
       expect(pipeline).toContain('name: CONFIGURATION_YAML_PATH');
       expect(pipeline).toContain("'Extract All APIs'");
-      expect(pipeline).toContain("'configuration.extract.yaml'");
+      expect(pipeline).toContain("'configuration.extractor.yaml'");
     });
 
     it('should include runtime parameters for resource group and service name', () => {

--- a/tests/unit/templates/configs/config-templates.test.ts
+++ b/tests/unit/templates/configs/config-templates.test.ts
@@ -15,42 +15,42 @@ describe('configs/filter-config', () => {
       expect(config).toContain('# APIM Extract Filter Configuration');
     });
 
-    it('should include commented examples for apiNames', () => {
+    it('should include commented examples for apis', () => {
       const config = generateFilterConfig();
-      expect(config).toContain('# apiNames:');
+      expect(config).toContain('# apis:');
     });
 
-    it('should include commented examples for productNames', () => {
+    it('should include commented examples for products', () => {
       const config = generateFilterConfig();
-      expect(config).toContain('# productNames:');
+      expect(config).toContain('# products:');
     });
 
-    it('should include commented examples for backendNames', () => {
+    it('should include commented examples for backends', () => {
       const config = generateFilterConfig();
-      expect(config).toContain('# backendNames:');
+      expect(config).toContain('# backends:');
     });
 
-    it('should include commented examples for namedValueNames', () => {
+    it('should include commented examples for namedValues', () => {
       const config = generateFilterConfig();
-      expect(config).toContain('# namedValueNames:');
+      expect(config).toContain('# namedValues:');
     });
 
-    it('should include commented examples for policyFragmentNames', () => {
+    it('should include commented examples for policyFragments', () => {
       const config = generateFilterConfig();
-      expect(config).toContain('# policyFragmentNames:');
+      expect(config).toContain('# policyFragments:');
     });
 
     it('should include commented examples for all supported filter fields', () => {
       const config = generateFilterConfig();
       const fields = [
-        'gatewayNames',
-        'versionSetNames',
-        'groupNames',
-        'subscriptionNames',
-        'schemaNames',
-        'policyRestrictionNames',
-        'documentationNames',
-        'workspaceNames',
+        'gateways',
+        'versionSets',
+        'groups',
+        'subscriptions',
+        'schemas',
+        'policyRestrictions',
+        'documentations',
+        'workspaces',
       ];
       fields.forEach((field) => {
         expect(config).toContain(`# ${field}:`);
@@ -60,8 +60,8 @@ describe('configs/filter-config', () => {
     it('should document empty arrays as exclude-all behavior', () => {
       const config = generateFilterConfig();
       expect(config).toContain('# - Set a section to an empty array ([]) to exclude ALL resources of that type');
-      expect(config).toContain('#   gatewayNames: []');
-      expect(config).toContain('#   subscriptionNames: []');
+      expect(config).toContain('#   gateways: []');
+      expect(config).toContain('#   subscriptions: []');
     });
 
     it('should not have any uncommented configuration by default', () => {

--- a/tests/unit/templates/github-actions/extract-workflow.test.ts
+++ b/tests/unit/templates/github-actions/extract-workflow.test.ts
@@ -26,7 +26,7 @@ describe('github-actions/extract-workflow', () => {
       expect(workflow).toContain('CONFIGURATION_YAML_PATH:');
       expect(workflow).toContain('type: choice');
       expect(workflow).toContain('Extract All APIs');
-      expect(workflow).toContain('configuration.extract.yaml');
+      expect(workflow).toContain('configuration.extractor.yaml');
     });
 
     it('should include ENVIRONMENT choice input', () => {
@@ -68,7 +68,7 @@ describe('github-actions/extract-workflow', () => {
       const lines = workflow.split('\n');
       const withConfigStart = lines.findIndex((l) => l.includes('Run APIM Extract (With Configuration)'));
       const withConfigSection = lines.slice(withConfigStart).join('\n');
-      expect(withConfigSection).toContain('--filter configuration.extract.yaml');
+      expect(withConfigSection).toContain('--filter configuration.extractor.yaml');
     });
 
     it('should use custom artifact directory in extract command', () => {


### PR DESCRIPTION
## Summary

Fully aligns the apiops-cli filter and override configuration formats with the [APIOps Toolkit](https://github.com/Azure/apiops) so customers can use their existing Toolkit configuration files without any changes.

Closes #114

## Changes

### Filter Configuration
- Renamed all filter keys from `*Names` suffix to bare camelCase plurals matching the Toolkit (`apiNames` → `apis`, `backendNames` → `backends`, etc.)
- Legacy `*Names` keys accepted as backward-compatible aliases with deprecation warnings
- Renamed filter config filename from `configuration.extract.yaml` → `configuration.extractor.yaml` across templates, CI/CD workflows, and documentation
- Added nested API sub-resource filtering — per-API control over operations, diagnostics, schemas, and releases
- Added `workspaces` filter support
- Fixed `workspaces: []` (empty array) semantics to correctly exclude all workspaces

### Override Configuration
- Replaced typed override interfaces (`NamedValueOverride`, `BackendOverride`, etc.) with a generic `OverrideEntry` model using `properties: Record<string, unknown>` — matches the Toolkit's deep-merge behavior and is forward-compatible with any new ARM properties
- All 14 Toolkit override sections now supported: `apis`, `backends`, `diagnostics`, `loggers`, `namedValues`, `products`, `subscriptions`, `tags`, `gateways`, `certificates`, `groups`, `policyFragments`, `schemas`, `versionSets`
- Nested child overrides (e.g., API → Diagnostics, API → Operations, API → Policy, Product → Policy)
- 3-level grandchild overrides (API → Operation → Policy)
- Policy overrides now applied during publish (matching Toolkit behavior)
- Case-insensitive override name matching
- Duplicate override name detection with warnings
- `apimServiceName` root-level field gracefully handled — logs info that CLI uses `--service-name` flag instead, and ignores the field

### Validation & DX
- Unknown filter/override keys produce warnings instead of silently ignoring
- Updated `apiops init` templates with all sections and nested examples
- Updated docs (filtering-resources.md, environment-overrides.md) with full format reference

### Tests
- 953 tests passing (18 new tests for nested filter/override functionality)
- Lint and TypeScript compilation clean

## Files Changed (15)

**Source (7):** `config.ts`, `config-loader.ts`, `filter-service.ts`, `override-merger.ts`, `resource-publisher.ts`, `transitive-resolver.ts`, `workspace-extractor.ts`
**Tests (4):** `config-loader.test.ts`, `filter-service.test.ts`, `override-merger.test.ts`, `resource-publisher.test.ts`
**Docs (2):** `filtering-resources.md`, `environment-overrides.md`
**Templates (2):** `filter-config.ts`, `override-config.ts`