### PR TITLE
enable workspace testing on all V2 SKUs

### DIFF
--- a/src/models/resource-types.ts
+++ b/src/models/resource-types.ts
@@ -41,7 +41,7 @@ export enum ResourceType {
   GraphQLResolverPolicy = 'GraphQLResolverPolicy',
   /** MCP (Model Context Protocol) server configuration per API. Singleton per API. */
   McpServer = 'McpServer',
-  /** Premium/PremiumV2 workspace container. */
+  /** Workspace container (Premium and all V2 SKUs). */
   Workspace = 'Workspace',
 }
 

--- a/tests/integration/all-resource-types/Compare-ApimInstance.ps1
+++ b/tests/integration/all-resource-types/Compare-ApimInstance.ps1
@@ -714,7 +714,7 @@ try {
         }
     }
     catch {
-        Write-Host "  ⚠️  Workspaces not available (requires Premium/PremiumV2): $_" -ForegroundColor Yellow
+        Write-Host "  ⚠️  Workspaces not available (requires Premium or V2 SKU): $_" -ForegroundColor Yellow
     }
 
     # ── Summary ─────────────────────────────────────────────────────────────

--- a/tests/integration/all-resource-types/Test-ExtractedArtifact.ps1
+++ b/tests/integration/all-resource-types/Test-ExtractedArtifact.ps1
@@ -21,7 +21,7 @@
   Path to expected-structure.json manifest file.
 
 .PARAMETER SkuName
-  APIM SKU name (StandardV2, Developer, Premium, Standard, PremiumV2) to handle SKU-variant
+  APIM SKU name (Developer, Premium, Standard, BasicV2, StandardV2, PremiumV2) to handle SKU-variant
   resources. Default: StandardV2.
 
 .EXAMPLE
@@ -36,6 +36,7 @@ param(
     [Parameter(Mandatory)]
     [string]$ManifestFile,
 
+    [ValidateSet('Developer', 'Premium', 'Standard', 'BasicV2', 'StandardV2', 'PremiumV2')]
     [string]$SkuName = 'StandardV2'
 )
 

--- a/tests/integration/all-resource-types/bicep/source-apim-post-activation.bicep
+++ b/tests/integration/all-resource-types/bicep/source-apim-post-activation.bicep
@@ -2,7 +2,7 @@
 param apimName string
 
 @description('APIM SKU name. Classic SKUs support docs/wiki/policyRestriction.')
-@allowed(['Developer', 'Premium', 'StandardV2', 'PremiumV2'])
+@allowed(['Developer', 'Premium', 'BasicV2', 'StandardV2', 'PremiumV2'])
 param skuName string
 
 var isClassicSku = skuName == 'Developer' || skuName == 'Premium'

--- a/tests/integration/all-resource-types/bicep/source-apim.bicep
+++ b/tests/integration/all-resource-types/bicep/source-apim.bicep
@@ -26,8 +26,8 @@ param publisherEmail string
 @description('Publisher name shown in the developer portal.')
 param publisherName string = 'APIOps BVT'
 
-@description('APIM SKU name. Use StandardV2/PremiumV2 for v2 tiers, or Developer/Premium/Standard for classic.')
-@allowed(['Developer', 'Premium', 'Standard', 'StandardV2', 'PremiumV2'])
+@description('APIM SKU name. Use BasicV2/StandardV2/PremiumV2 for v2 tiers, or Developer/Premium/Standard for classic.')
+@allowed(['Developer', 'Premium', 'Standard', 'BasicV2', 'StandardV2', 'PremiumV2'])
 param skuName string = 'StandardV2'
 
 @description('Application Insights name for logger/diagnostic testing.')
@@ -49,7 +49,7 @@ param logAnalyticsName string = 'bvt-${uniqueString(resourceGroup().id)}-src-law
 var isClassicSku = skuName == 'Developer' || skuName == 'Premium' || skuName == 'Standard'
 var apimSkuCapacity = isClassicSku ? 1 : 1
 var supportsSelfHostedGateway = skuName == 'Developer' || skuName == 'Premium'
-var supportsWorkspaces = skuName == 'Premium' || skuName == 'PremiumV2'
+var supportsWorkspaces = skuName == 'Premium' || skuName == 'BasicV2' || skuName == 'StandardV2' || skuName == 'PremiumV2'
 
 // Minimal but valid OpenAPI 3.0 spec
 var openApiSpec = '''

--- a/tests/integration/all-resource-types/bicep/target-apim.bicep
+++ b/tests/integration/all-resource-types/bicep/target-apim.bicep
@@ -30,7 +30,7 @@ param publisherEmail string
 param publisherName string = 'APIOps BVT'
 
 @description('APIM SKU name. Must match the source instance SKU.')
-@allowed(['Developer', 'Premium', 'Standard', 'StandardV2', 'PremiumV2'])
+@allowed(['Developer', 'Premium', 'Standard', 'BasicV2', 'StandardV2', 'PremiumV2'])
 param skuName string = 'StandardV2'
 
 @description('Application Insights name for logger/diagnostic testing.')

--- a/tests/integration/all-resource-types/expected-structure.json
+++ b/tests/integration/all-resource-types/expected-structure.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "skuVariants": {
     "note": "Some resources only exist on certain SKUs",
-    "workspaces": ["Premium", "PremiumV2"],
+    "workspaces": ["Premium", "BasicV2", "StandardV2", "PremiumV2"],
     "selfHostedGateways": ["Developer", "Premium"]
   },
   "serviceLevelArtifacts": {
@@ -633,9 +633,9 @@
     }
   },
   "workspaces": {
-    "note": "Workspaces only exist on Premium and PremiumV2 SKUs",
+    "note": "Workspaces exist on Premium and all V2 SKUs (BasicV2, StandardV2, PremiumV2)",
     "skuDependent": true,
-    "skuFilter": ["Premium", "PremiumV2"],
+    "skuFilter": ["Premium", "BasicV2", "StandardV2", "PremiumV2"],
     "expected": [
       {
         "name": "src-workspace",

--- a/tests/integration/all-resource-types/phases/run-phase1-deploy-source.ps1
+++ b/tests/integration/all-resource-types/phases/run-phase1-deploy-source.ps1
@@ -19,7 +19,7 @@
   APIM instance name. Default: ks-apim-bvt.
 
 .PARAMETER SkuName
-  APIM SKU. Default: StandardV2. Allowed: Developer, Premium, StandardV2, PremiumV2.
+  APIM SKU. Default: StandardV2. Allowed: Developer, Premium, BasicV2, StandardV2, PremiumV2.
 
 .PARAMETER Destroy
   Tear down: deletes the entire resource group.
@@ -45,7 +45,7 @@ param(
 
     [string]$Location = 'eastus2',
 
-    [ValidateSet('Developer', 'Premium', 'Standard', 'StandardV2', 'PremiumV2')]
+    [ValidateSet('Developer', 'Premium', 'Standard', 'BasicV2', 'StandardV2', 'PremiumV2')]
     [string]$SkuName = 'StandardV2',
 
     [string]$ApimName,

--- a/tests/integration/all-resource-types/phases/run-phase1-deploy-target.ps1
+++ b/tests/integration/all-resource-types/phases/run-phase1-deploy-target.ps1
@@ -18,7 +18,7 @@
   Azure region. Default: eastus2.
 
 .PARAMETER SkuName
-  APIM SKU. Default: StandardV2. Allowed: Developer, Premium, StandardV2, PremiumV2.
+  APIM SKU. Default: StandardV2. Allowed: Developer, Premium, BasicV2, StandardV2, PremiumV2.
 #>
 
 [CmdletBinding()]
@@ -31,7 +31,7 @@ param(
 
     [string]$Location = 'eastus2',
 
-    [ValidateSet('Developer', 'Premium', 'Standard', 'StandardV2', 'PremiumV2')]
+    [ValidateSet('Developer', 'Premium', 'Standard', 'BasicV2', 'StandardV2', 'PremiumV2')]
     [string]$SkuName = 'StandardV2',
 
     [string]$ApimName,

--- a/tests/integration/all-resource-types/phases/run-phase1-deploy.ps1
+++ b/tests/integration/all-resource-types/phases/run-phase1-deploy.ps1
@@ -54,7 +54,7 @@ param(
     [Parameter(Mandatory)]
     [string]$TargetResourceGroup,
 
-    [ValidateSet('Developer', 'Premium', 'Standard', 'StandardV2', 'PremiumV2')]
+    [ValidateSet('Developer', 'Premium', 'Standard', 'BasicV2', 'StandardV2', 'PremiumV2')]
     [string]$SkuName = 'StandardV2',
 
     [string]$Location = 'eastus2',
@@ -243,7 +243,7 @@ $targetName = if ($targetOutputs -and $targetOutputs.apimServiceName.value) { $t
     $apimName
 }
 
-if ($SkuName -in @('Developer', 'Premium', 'PremiumV2')) {
+if ($SkuName -in @('Developer', 'Premium', 'BasicV2', 'StandardV2', 'PremiumV2')) {
     $postActivationState = az deployment group list `
         --resource-group $sourceRg `
         --query "sort_by([?starts_with(name, 'source-apim-post-activation-')], &properties.timestamp)[-1].properties.provisioningState" `

--- a/tests/integration/all-resource-types/phases/run-phase3-validate-extract.ps1
+++ b/tests/integration/all-resource-types/phases/run-phase3-validate-extract.ps1
@@ -23,7 +23,7 @@
 
 [CmdletBinding()]
 param(
-    [ValidateSet('Developer', 'Premium', 'Standard', 'StandardV2', 'PremiumV2')]
+    [ValidateSet('Developer', 'Premium', 'Standard', 'BasicV2', 'StandardV2', 'PremiumV2')]
     [string]$SkuName = 'StandardV2',
 
     [ValidateSet('Info', 'Verbose', 'Debug')]

--- a/tests/integration/all-resource-types/run-roundtrip-test.ps1
+++ b/tests/integration/all-resource-types/run-roundtrip-test.ps1
@@ -57,7 +57,7 @@ param(
     [Parameter()]
     [string]$TargetSubscriptionId,
 
-    [ValidateSet('Developer', 'Premium', 'Standard', 'StandardV2', 'PremiumV2')]
+    [ValidateSet('Developer', 'Premium', 'Standard', 'BasicV2', 'StandardV2', 'PremiumV2')]
     [string]$SkuName = 'StandardV2',
 
     [string]$Location = 'centralus',


### PR DESCRIPTION
## Summary

Enable workspace resource deployment, extraction, publishing, and comparison in integration tests for **all V2 SKUs** (BasicV2, StandardV2, PremiumV2), not just Premium/PremiumV2.

As of the [June 2026 GA announcement](https://stackfeed.io/article/2026-06-02-generally-available-azure-api-management-workspaces-now-support-the-built-in-gateway), Azure API Management workspaces are supported on all V2 tiers via the built-in gateway.

## Changes

- **`tests/integration/all-resource-types/bicep/source-apim.bicep`** — Added `BasicV2` and `StandardV2` to `supportsWorkspaces` condition
- **`tests/integration/all-resource-types/expected-structure.json`** — Updated `skuVariants.workspaces`, `skuFilter`, and note to include all V2 SKUs

## Impact

The default `StandardV2` test runs will now automatically include workspace resource testing, significantly increasing coverage without requiring a more expensive Premium SKU.

## Related Issue(s)

Closes #126