### PR TITLE
Disable workspace testing for BasicV2 SKU

### DIFF
--- a/tests/integration/all-resource-types/bicep/source-apim.bicep
+++ b/tests/integration/all-resource-types/bicep/source-apim.bicep
@@ -49,7 +49,7 @@ param logAnalyticsName string = 'bvt-${uniqueString(resourceGroup().id)}-src-law
 var isClassicSku = skuName == 'Developer' || skuName == 'Premium' || skuName == 'Standard'
 var apimSkuCapacity = isClassicSku ? 1 : 1
 var supportsSelfHostedGateway = skuName == 'Developer' || skuName == 'Premium'
-var supportsWorkspaces = skuName == 'Premium' || skuName == 'BasicV2' || skuName == 'StandardV2' || skuName == 'PremiumV2'
+var supportsWorkspaces = skuName == 'Premium' || skuName == 'StandardV2' || skuName == 'PremiumV2'
 
 // Minimal but valid OpenAPI 3.0 spec
 var openApiSpec = '''

--- a/tests/integration/all-resource-types/expected-structure.json
+++ b/tests/integration/all-resource-types/expected-structure.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "skuVariants": {
     "note": "Some resources only exist on certain SKUs",
-    "workspaces": ["Premium", "BasicV2", "StandardV2", "PremiumV2"],
+    "workspaces": ["Premium", "StandardV2", "PremiumV2"],
     "selfHostedGateways": ["Developer", "Premium"]
   },
   "serviceLevelArtifacts": {
@@ -633,9 +633,9 @@
     }
   },
   "workspaces": {
-    "note": "Workspaces exist on Premium and all V2 SKUs (BasicV2, StandardV2, PremiumV2)",
+    "note": "Workspaces exist on Premium and StandardV2/PremiumV2 (BasicV2 blocked by MethodNotAllowedInPricingTier as of June 2026)",
     "skuDependent": true,
-    "skuFilter": ["Premium", "BasicV2", "StandardV2", "PremiumV2"],
+    "skuFilter": ["Premium", "StandardV2", "PremiumV2"],
     "expected": [
       {
         "name": "src-workspace",


### PR DESCRIPTION
## Summary

Removes BasicV2 from the `supportsWorkspaces` gate in integration tests. Despite [official Microsoft docs](https://learn.microsoft.com/en-us/azure/api-management/v2-service-tiers-overview#feature-comparison-v2-tiers-versus-v1-tiers) stating BasicV2 supports workspaces, the Azure APIM resource provider rejects workspace creation with `MethodNotAllowedInPricingTier`.

## Investigation

- Confirmed via direct REST API calls against a live BasicV2 instance — even `GET /workspaces` returns `MethodNotAllowedInPricingTier` (tested across multiple regions and API versions `2024-05-01` and `2025-09-01-preview`)
- Confirmed StandardV2 **does** support workspaces (both list and create succeed)

## Changes

- **`source-apim.bicep`**: Removed `BasicV2` from the `supportsWorkspaces` variable so workspace resources are not deployed for BasicV2
- **`expected-structure.json`**: Removed `BasicV2` from workspace-related `skuFilter` entries and updated the note

## Related Issue(s)

Follows up on PR #128 which enabled workspace testing for all V2 SKUs.