### PR TITLE
Remove speckit task IDs, add doc links to templates, fix test type errors

### DIFF
--- a/src/cli/extract-command.ts
+++ b/src/cli/extract-command.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T028 & T029: Extract command CLI registration
+ * Extract command CLI registration
  * Commander subcommand with --resource-group, --service-name, --output,
  * --filter, --no-transitive, --spec-format flags.
  * Includes --format json: machine-readable JSON output mode.
@@ -131,7 +131,7 @@ async function executeExtract(
 }
 
 /**
- * T029: JSON output mode for extract.
+ * JSON output mode for extract.
  * Machine-readable JSON to stdout with resource counts and file paths.
  */
 function outputJson(result: ExtractionResult): void {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT license.
 
 /**
- * T019: Commander program entry point
+ * Commander program entry point
  * Sets up global options and subcommand registration pattern
  */
 
@@ -51,7 +51,7 @@ program.hook('preAction', (thisCommand) => {
 
   logger.configure({ level: parseLogLevel(opts.logLevel ?? 'info') });
 
-  // T040: Set DefaultAzureCredential env vars from explicit auth flags.
+  // Set DefaultAzureCredential env vars from explicit auth flags.
   // This ensures the ServicePrincipal credential is tried first,
   // avoiding interactive browser prompts in CI/CD pipelines.
   if (opts.clientId) {

--- a/src/cli/init-command.ts
+++ b/src/cli/init-command.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T050: Register init command
+ * Register init command
  * Commander subcommand with --ci, --non-interactive, --artifact-dir, --environments flags
  * Wire to init-service
  */

--- a/src/cli/publish-command.ts
+++ b/src/cli/publish-command.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T037 & T038: Publish command CLI registration
+ * Publish command CLI registration
  * Commander subcommand with --resource-group, --service-name, --source,
  * --overrides, --dry-run, --delete-unmatched flags.
- * Includes --format json: machine-readable JSON output mode (T038).
+ * Includes --format json: machine-readable JSON output mode.
  */
 
 import { Command } from 'commander';
@@ -173,7 +173,7 @@ export function hasMutuallyExclusivePublishOptions(
 }
 
 /**
- * T038: JSON output mode for publish.
+ * JSON output mode for publish.
  * Machine-readable JSON to stdout with action list and summary.
  */
 function outputJson(result: PublishResult): void {

--- a/src/clients/apim-client.ts
+++ b/src/clients/apim-client.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T016: Azure REST HTTP client implementing IApimClient
+ * Azure REST HTTP client implementing IApimClient
  * Uses @azure/identity DefaultAzureCredential for auth
  * Handles pagination, retry, rate limiting, and long-running operations
  */

--- a/src/clients/artifact-store.ts
+++ b/src/clients/artifact-store.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T017: Filesystem artifact store implementing IArtifactStore
+ * Filesystem artifact store implementing IArtifactStore
  * Read/write resource JSON files, policy XML, API specs, associations, wiki markdown
  */
 

--- a/src/clients/iapim-client.ts
+++ b/src/clients/iapim-client.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T009: IApimClient interface
+ * IApimClient interface
  * Abstraction over Azure APIM REST API calls
  */
 

--- a/src/clients/iartifact-store.ts
+++ b/src/clients/iartifact-store.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T010: IArtifactStore interface
+ * IArtifactStore interface
  * Abstraction over local filesystem for reading/writing APIM artifact files
  */
 

--- a/src/lib/cloud-config.ts
+++ b/src/lib/cloud-config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T039: Sovereign cloud configuration
+ * Sovereign cloud configuration
  * Maps the --cloud CLI flag to ARM base URLs and auth scopes for
  * Azure Public, China, US Government, and Germany clouds.
  */

--- a/src/lib/config-loader.ts
+++ b/src/lib/config-loader.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T015: YAML config loader with validation
+ * YAML config loader with validation
  * Parse filter YAML, override YAML, and OTel config files
  */
 

--- a/src/lib/dependency-graph.ts
+++ b/src/lib/dependency-graph.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T011: Static dependency graph implementation
+ * Static dependency graph implementation
  * 33 resource types, 4 tiers, topological sort, cycle-detection assertion
  */
 

--- a/src/lib/exit-codes.ts
+++ b/src/lib/exit-codes.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T041: Exit code constants and aggregation
+ * Exit code constants and aggregation
  * Provides standardised exit codes and a reusable aggregation function
  * for combining per-resource results into a single process exit code.
  */

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 /**
- * T014: Structured logger with stderr output
+ * Structured logger with stderr output
  * Supports log levels, timestamps, and --log-level option.
  * Sanitizes sensitive data from log output per Constitution §VIII.
  */

--- a/src/lib/parallel-runner.ts
+++ b/src/lib/parallel-runner.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T018: Parallel execution runner with concurrency control.
+ * Parallel execution runner with concurrency control.
  *
  * Custom implementation (no external dependencies such as p-limit) to limit
  * concurrent APIM REST API calls and avoid 429 rate limiting. Azure APIM has
  * strict per-second request limits, so unbounded Promise.all() would fire all
  * requests simultaneously, triggering throttling. Bounded concurrency is a
- * requirement from research.md R8 and justified in tasks.md T018.
+ * requirement from research.md.
  *
  * Built-in implementation without external dependencies (no p-limit).
  */

--- a/src/lib/resource-path.ts
+++ b/src/lib/resource-path.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T013: Resource descriptor ↔ artifact file path mapping
+ * Resource descriptor ↔ artifact file path mapping
  * Map descriptor to directory/file paths per data-model.md artifact conventions
  */
 

--- a/src/lib/resource-uri.ts
+++ b/src/lib/resource-uri.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T012: Resource descriptor ↔ ARM URI mapping
+ * Resource descriptor ↔ ARM URI mapping
  * Build full ARM URL from ApimServiceContext + ResourceDescriptor
  */
 

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T008: Config interfaces
+ * Config interfaces
  * ExtractConfig, FilterConfig, PublishConfig, OverrideConfig, InitConfig
  */
 

--- a/src/models/resource-types.ts
+++ b/src/models/resource-types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T006: ResourceType enum and metadata
+ * ResourceType enum and metadata
  * All 34 APIM resource types with ARM path suffixes, artifact directories, and info file names
  */
 

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T007: Core TypeScript interfaces
+ * Core TypeScript interfaces
  * ResourceDescriptor, ResourcePayload, ApimServiceContext, DependencyEdge
  */
 

--- a/src/services/api-extractor.ts
+++ b/src/services/api-extractor.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T022: API-specific extraction logic
+ * API-specific extraction logic
  * API revisions, API specifications, operations & operation policies,
  * GraphQL resolvers & resolver policies, API tags, diagnostics, schemas,
  * releases, tag descriptions, wikis.

--- a/src/services/api-publisher.ts
+++ b/src/services/api-publisher.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T032: API publisher with revision handling
+ * API publisher with revision handling
  * Create root API first, then revisions in numeric order with forced revision numbers.
  * Publish operations, policies, schemas, releases, resolvers, tag descriptions, wikis per FR-024.
  * Handle SOAP/WSDL import via ?import=true&format=wsdl-link query parameter.

--- a/src/services/delete-unmatched-service.ts
+++ b/src/services/delete-unmatched-service.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T035: Delete unmatched resources service
+ * Delete unmatched resources service
  * List current APIM resources, diff against artifact descriptors,
  * generate DELETE actions in reverse dependency order.
  * Requires --delete-unmatched flag per FR-017.

--- a/src/services/dry-run-reporter.ts
+++ b/src/services/dry-run-reporter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T034: Dry-run reporter
+ * Dry-run reporter
  * Compare artifact resources vs APIM state, output [DRY RUN] PUT/DELETE/SKIP lines.
  * Summary counts per contracts/cli-commands.md.
  */

--- a/src/services/extract-service.ts
+++ b/src/services/extract-service.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T020: Extraction orchestrator
+ * Extraction orchestrator
  * Coordinates resource type extraction across dependency tiers
  * using dependency-graph.ts and parallel-runner.ts.
  * Per-resource status output per FR-023.

--- a/src/services/filter-service.ts
+++ b/src/services/filter-service.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T024: Filter service
+ * Filter service
  * Load FilterConfig, apply inclusive allowlist per resource type,
  * case-insensitive matching, API root-name matching for revisions.
  */

--- a/src/services/git-diff-service.ts
+++ b/src/services/git-diff-service.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T036: Git diff service
+ * Git diff service
  * Compute changed resource artifacts between commits using simple-git.
  * Maps file paths to ResourceDescriptors for incremental publish.
  */

--- a/src/services/identity-guide-service.ts
+++ b/src/services/identity-guide-service.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T048: Identity setup guide generator
+ * Identity setup guide generator
  * Step-by-step instructions for service principal, RBAC, federated credentials,
  * pipeline secrets/service connections. Optional az CLI automation per FR-021.
  */

--- a/src/services/init-service.ts
+++ b/src/services/init-service.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T042 & T051: Init orchestrator service
+ * Init orchestrator service
  * Coordinates interactive prompts or flag-based config, generates scaffold files,
  * and detects existing file conflicts
  */

--- a/src/services/override-merger.ts
+++ b/src/services/override-merger.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T033: Override merger service
+ * Override merger service
  * Apply environment-specific overrides from OverrideConfig to resource JSON payloads.
  * Deep-merges with case-insensitive key matching; supports nested sub-resource overrides.
  * Handles all Toolkit override sections with generic property passthrough.

--- a/src/services/product-extractor.ts
+++ b/src/services/product-extractor.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T023: Product-specific extraction logic
+ * Product-specific extraction logic
  * Product associations (apis.json, groups.json, tags.json), product policies, product wikis.
  */
 

--- a/src/services/prompt-service.ts
+++ b/src/services/prompt-service.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T049: Interactive prompt handler
+ * Interactive prompt handler
  * TTY detection, question prompts for CI provider/artifact dir/environments
  * --non-interactive bypass per FR-022
  */

--- a/src/services/publish-service.ts
+++ b/src/services/publish-service.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T030: Publish orchestration service
+ * Publish orchestration service
  * Coordinates PUT/DELETE across dependency tiers in topological order
  * PUTs in dependency order (tier 1-4), DELETEs in reverse order (tier 4-1)
  */

--- a/src/services/resource-extractor.ts
+++ b/src/services/resource-extractor.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T021: Resource type extractor
+ * Resource type extractor
  * Generic extract logic: list resources via IApimClient, write each to IArtifactStore.
  * Handles all 33 types using ResourceType metadata. Preserves opaque JSON per FR-009.
  */

--- a/src/services/resource-publisher.ts
+++ b/src/services/resource-publisher.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T031: Generic resource publisher
+ * Generic resource publisher
  * Read resource from IArtifactStore, apply overrides, PUT via IApimClient.
  * Handles all 33 resource types using ResourceType metadata.
  * MUST preserve opaque JSON per FR-009.

--- a/src/services/secret-redactor.ts
+++ b/src/services/secret-redactor.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T026: Secret redaction service
+ * Secret redaction service
  * Detect properties.secret === true on named values,
  * replace properties.value with redaction marker.
  */

--- a/src/services/transitive-resolver.ts
+++ b/src/services/transitive-resolver.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T025: Transitive dependency resolver
+ * Transitive dependency resolver
  * Scan policies for named value refs, backend refs, policy fragment refs.
  * Scan apiInformation.json for apiVersionSetId.
  * Fixed-point expansion; --no-transitive bypass.

--- a/src/services/workspace-extractor.ts
+++ b/src/services/workspace-extractor.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T027: Workspace-scoped extraction
+ * Workspace-scoped extraction
  * List workspaces, extract workspace-scoped resources under workspaces/{name}/
  * using same resource-extractor with workspace context prefix.
  */

--- a/src/templates/azure-devops/extract-pipeline.ts
+++ b/src/templates/azure-devops/extract-pipeline.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T045: Azure DevOps extract pipeline template
+ * Azure DevOps extract pipeline template
  * Manual trigger with environment choice, configuration choice, and auto-PR creation
  */
 

--- a/src/templates/azure-devops/publish-pipeline.ts
+++ b/src/templates/azure-devops/publish-pipeline.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T046: Azure DevOps publish pipeline template
+ * Azure DevOps publish pipeline template
  * Multi-stage pipeline with commit ID choice, environment selection, and variable groups
  */
 

--- a/src/templates/configs/filter-config.ts
+++ b/src/templates/configs/filter-config.ts
@@ -1,13 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T047: Sample filter configuration template
+ * Sample filter configuration template
  * Generates a sample configuration.extractor.yaml file
  */
 
 export function generateFilterConfig(): string {
   return `# APIM Extract Filter Configuration
 # Customize this file to control which resources are extracted
+# For full format details and examples, see:
+# https://github.com/Azure/apiops-cli/blob/main/docs/guides/filtering-resources.md
 
 # Extract only specific APIs by name
 # apis:

--- a/src/templates/configs/override-config.ts
+++ b/src/templates/configs/override-config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T047: Sample override configuration template per environment
+ * Sample override configuration template per environment
  * Generates environment-specific configuration.{env}.yaml files
  */
 
@@ -9,6 +9,8 @@ export function generateOverrideConfig(environment: string): string {
   return `# APIM Override Configuration for ${environment} environment
 # Customize resource properties for this specific environment
 # All APIOps Toolkit override sections are supported.
+# For full format details and examples, see:
+# https://github.com/Azure/apiops-cli/blob/main/docs/guides/environment-overrides.md
 
 # Override named values (e.g., API keys, connection strings)
 # namedValues:

--- a/src/templates/github-actions/extract-workflow.ts
+++ b/src/templates/github-actions/extract-workflow.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T043: GitHub Actions extract workflow template
+ * GitHub Actions extract workflow template
  * Generates extract workflow with manual trigger, configuration choice, and auto-PR creation
  */
 

--- a/src/templates/github-actions/publish-workflow.ts
+++ b/src/templates/github-actions/publish-workflow.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * T044: GitHub Actions publish workflow template
+ * GitHub Actions publish workflow template
  * Push-to-main trigger with commit ID choice, environment selection, and multi-env stages
  */
 

--- a/tests/unit/cli/extract-command.test.ts
+++ b/tests/unit/cli/extract-command.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T028/T029: Extract command CLI registration
+ * Unit tests for Extract command CLI registration
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/cli/init-command.test.ts
+++ b/tests/unit/cli/init-command.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T050: Init command CLI registration
+ * Unit tests for Init command CLI registration
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/cli/publish-command.test.ts
+++ b/tests/unit/cli/publish-command.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T037/T038: Publish command CLI registration
+ * Unit tests for Publish command CLI registration
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/lib/cloud-config.test.ts
+++ b/tests/unit/lib/cloud-config.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for cloud-config module (T039).
+ * Unit tests for cloud-config module.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/lib/exit-codes.test.ts
+++ b/tests/unit/lib/exit-codes.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for exit-codes module (T041).
+ * Unit tests for exit-codes module.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/services/api-product-extractor.test.ts
+++ b/tests/unit/services/api-product-extractor.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T022: API-specific extraction and T023: Product-specific extraction
+ * Unit tests for API-specific extraction and Product-specific extraction
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -31,8 +31,10 @@ function createMockClient(overrides: Record<string, unknown> = {}) {
     getResource: vi.fn().mockResolvedValue(undefined),
     putResource: vi.fn(),
     deleteResource: vi.fn(),
+    patchResource: vi.fn().mockResolvedValue(undefined),
     listApiRevisions: async function* () {},
     getApiSpecification: vi.fn().mockResolvedValue(undefined),
+    validatePreFlight: vi.fn().mockResolvedValue(undefined),
     _resources: resources,
     ...overrides,
   };

--- a/tests/unit/services/api-publisher.test.ts
+++ b/tests/unit/services/api-publisher.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T032: API publisher with revision handling
+ * Unit tests for API publisher with revision handling
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/tests/unit/services/delete-unmatched-service.test.ts
+++ b/tests/unit/services/delete-unmatched-service.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T035: Delete unmatched resources service
+ * Unit tests for Delete unmatched resources service
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -22,8 +22,10 @@ function createMockClient(apimResources: Map<ResourceType, Record<string, unknow
     getResource: vi.fn(),
     putResource: vi.fn(),
     deleteResource: vi.fn(),
+    patchResource: vi.fn().mockResolvedValue(undefined),
     listApiRevisions: async function* () {},
     getApiSpecification: vi.fn(),
+    validatePreFlight: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -177,7 +179,7 @@ describe('delete-unmatched-service', () => {
     it('should handle APIM listing errors gracefully', async () => {
       const client = createMockClient();
       // Override listResources to throw error
-      client.listResources = (): AsyncIterable<Record<string, unknown>> => {
+      client.listResources = () => {
         throw new Error('Network error');
       };
       const store = createMockStore([]);

--- a/tests/unit/services/dry-run-reporter.test.ts
+++ b/tests/unit/services/dry-run-reporter.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T034: Dry-run reporter service
+ * Unit tests for Dry-run reporter service
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -34,6 +34,7 @@ function createMockClient(
     ),
     putResource: vi.fn(async () => ({ name: 'mock' })),
     deleteResource: vi.fn(async () => true),
+    patchResource: vi.fn(async () => ({})),
     listApiRevisions: async function* () {},
     getApiSpecification: vi.fn(async () => undefined),
     validatePreFlight: vi.fn(async () => {}),

--- a/tests/unit/services/extract-service.test.ts
+++ b/tests/unit/services/extract-service.test.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T020: Extract service orchestrator
+ * Unit tests for Extract service orchestrator
  */
 
 import { describe, it, expect, vi } from 'vitest';
 import { ResourceType } from '../../../src/models/resource-types.js';
-import { ApimServiceContext } from '../../../src/models/types.js';
+import { ApimServiceContext, ResourceDescriptor } from '../../../src/models/types.js';
 import { ExtractConfig, FilterConfig } from '../../../src/models/config.js';
 import { runExtraction } from '../../../src/services/extract-service.js';
 import { LogLevel } from '../../../src/lib/logger.js';
@@ -23,8 +23,10 @@ function createMockClient(resourcesByType: Partial<Record<ResourceType, Record<s
     getResource: vi.fn().mockResolvedValue(undefined),
     putResource: vi.fn(),
     deleteResource: vi.fn(),
+    patchResource: vi.fn().mockResolvedValue(undefined),
     listApiRevisions: async function* () {},
     getApiSpecification: vi.fn().mockResolvedValue(undefined),
+    validatePreFlight: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -197,7 +199,7 @@ describe('extract-service', () => {
         service: testContext,
         outputDir: '/output',
         includeTransitive: false,
-        verbose: false,
+        logLevel: LogLevel.INFO,
       };
 
       const result = await runExtraction(client, store, config);
@@ -230,7 +232,7 @@ describe('extract-service', () => {
         service: testContext,
         outputDir: '/output',
         includeTransitive: false,
-        verbose: false,
+        logLevel: LogLevel.INFO,
       };
 
       const result = await runExtraction(client, store, config);
@@ -301,7 +303,7 @@ describe('extract-service', () => {
       });
 
       // Handle GatewayApi requests for the gateway
-      client.listResources = async function* (_ctx, type, parent?) {
+      client.listResources = async function* (_ctx: ApimServiceContext, type: ResourceType, parent?: ResourceDescriptor) {
         if (type === ResourceType.Gateway) {
           yield { name: 'gw-1', properties: {} };
         }
@@ -336,7 +338,7 @@ describe('extract-service', () => {
         ],
       });
 
-      client.listResources = async function* (_ctx, type, _parent?) {
+      client.listResources = async function* (_ctx: ApimServiceContext, type: ResourceType, _parent?: ResourceDescriptor) {
         if (type === ResourceType.Gateway) {
           yield { name: 'gw-1', properties: {} };
         }

--- a/tests/unit/services/filter-service.test.ts
+++ b/tests/unit/services/filter-service.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T024: Filter service
+ * Unit tests for Filter service
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/services/git-diff-service.test.ts
+++ b/tests/unit/services/git-diff-service.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T036: Git diff service
+ * Unit tests for Git diff service
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/tests/unit/services/identity-guide-service.test.ts
+++ b/tests/unit/services/identity-guide-service.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T048: Identity setup guide generator
+ * Unit tests for Identity setup guide generator
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/services/init-service.test.ts
+++ b/tests/unit/services/init-service.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T042 & T051: Init orchestrator service
+ * Unit tests for Init orchestrator service
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/tests/unit/services/override-merger.test.ts
+++ b/tests/unit/services/override-merger.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T033: Override merger service
+ * Unit tests for Override merger service
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/services/product-publisher.test.ts
+++ b/tests/unit/services/product-publisher.test.ts
@@ -19,11 +19,12 @@ vi.mock('../../../src/services/resource-publisher.js', () => ({
 
 function createMockClient() {
   return {
-    listResources: async function* () {},
+    listResources: async function* (): AsyncGenerator<Record<string, unknown>> {},
     getResource: vi.fn(),
     putResource: vi.fn().mockResolvedValue(undefined),
     deleteResource: vi.fn().mockResolvedValue(true),
-    listApiRevisions: async function* () {},
+    patchResource: vi.fn().mockResolvedValue(undefined),
+    listApiRevisions: async function* (): AsyncGenerator<Record<string, unknown>> {},
     getApiSpecification: vi.fn(),
     validatePreFlight: vi.fn(),
   };

--- a/tests/unit/services/prompt-service.test.ts
+++ b/tests/unit/services/prompt-service.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T049: Interactive prompt handler
+ * Unit tests for Interactive prompt handler
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/tests/unit/services/publish-service.test.ts
+++ b/tests/unit/services/publish-service.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T030: Publish orchestration service
+ * Unit tests for Publish orchestration service
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/tests/unit/services/resource-extractor.test.ts
+++ b/tests/unit/services/resource-extractor.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T021: Resource type extractor
+ * Unit tests for Resource type extractor
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -29,8 +29,10 @@ function createMockClient(resources: Record<string, unknown>[] = []) {
     getResource: vi.fn().mockResolvedValue(resources[0] ?? undefined),
     putResource: vi.fn(),
     deleteResource: vi.fn(),
+    patchResource: vi.fn().mockResolvedValue(undefined),
     listApiRevisions: async function* () {},
     getApiSpecification: vi.fn().mockResolvedValue(undefined),
+    validatePreFlight: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/tests/unit/services/resource-publisher.test.ts
+++ b/tests/unit/services/resource-publisher.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T031: Resource publisher service
+ * Unit tests for Resource publisher service
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/tests/unit/services/secret-redactor.test.ts
+++ b/tests/unit/services/secret-redactor.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T026: Secret redaction service
+ * Unit tests for Secret redaction service
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/services/transitive-resolver.test.ts
+++ b/tests/unit/services/transitive-resolver.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T025: Transitive dependency resolver
+ * Unit tests for Transitive dependency resolver
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/services/workspace-extractor.test.ts
+++ b/tests/unit/services/workspace-extractor.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T027: Workspace-scoped extraction
+ * Unit tests for Workspace-scoped extraction
  */
 
 import { describe, it, expect, vi } from 'vitest';

--- a/tests/unit/templates/azure-devops/extract-pipeline.test.ts
+++ b/tests/unit/templates/azure-devops/extract-pipeline.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T045: Azure DevOps extract pipeline template
+ * Unit tests for Azure DevOps extract pipeline template
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/templates/azure-devops/publish-pipeline.test.ts
+++ b/tests/unit/templates/azure-devops/publish-pipeline.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T046: Azure DevOps publish pipeline template
+ * Unit tests for Azure DevOps publish pipeline template
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/templates/configs/config-templates.test.ts
+++ b/tests/unit/templates/configs/config-templates.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T047: Config templates
+ * Unit tests for Config templates
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/templates/github-actions/extract-workflow.test.ts
+++ b/tests/unit/templates/github-actions/extract-workflow.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T043: GitHub Actions extract workflow template
+ * Unit tests for GitHub Actions extract workflow template
  */
 
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/templates/github-actions/publish-workflow.test.ts
+++ b/tests/unit/templates/github-actions/publish-workflow.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * Unit tests for T044: GitHub Actions publish workflow template
+ * Unit tests for GitHub Actions publish workflow template
  */
 
 import { describe, it, expect } from 'vitest';


### PR DESCRIPTION
## Summary

Cleanup PR addressing three areas:

### 1. Remove speckit task ID references (`T0XX`) from comments
Stripped leftover `T047:`, `T028 & T029:`, etc. prefixes from JSDoc and inline comments across 68 source and test files. These were artifacts from the speckit planning tool and don't belong in user-facing or developer-facing code.

### 2. Add documentation links to user-facing config templates
- **`src/templates/configs/override-config.ts`** — added link to `docs/guides/environment-overrides.md`
- **`src/templates/configs/filter-config.ts`** — added link to `docs/guides/filtering-resources.md`

These links appear in the generated YAML config files so users can find the full format docs.

### 3. Fix TypeScript type errors in test mock clients
Several test files had mock `IApimClient` implementations missing `patchResource` and/or `validatePreFlight` methods added to the interface. Also fixed:
- `verbose` property (removed from `ExtractConfig`) → replaced with `logLevel`
- Implicit `any` on `parent` parameters in `async function*` overrides
- `AsyncGenerator<never>` inference from empty generator literals

**All 983 tests pass. `tsc -p tests/tsconfig.json --noEmit` is clean.**