### PR TITLE
Add wildcard filter matching and workspace sub-resource filtering

### DIFF
--- a/docs/commands/extract.md
+++ b/docs/commands/extract.md
@@ -95,17 +95,19 @@ For local development, `az login` is the simplest option. For CI/CD pipelines, u
 
 By default, `apiops extract` exports **all** resources from the APIM instance (34 resource types including APIs, products, backends, named values, tags, policies, and more).
 
-To extract only specific resources, pass a YAML filter file with `--filter`:
+To extract only specific resources, pass a YAML filter file with `--filter`. Filter entries support exact names and wildcard patterns (`*` for any characters, `?` for a single character):
 
 ```yaml
 # configuration.extractor.yaml
 apis:
   - echo-api
   - petstore-api
+  - prod-*              # Wildcard: all APIs starting with prod-
 products:
   - starter
 backends:
   - backend-api
+  - '*-internal'        # Wildcard: all backends ending with -internal
 namedValues:
   - api-key
 tags:

--- a/docs/commands/extract.md
+++ b/docs/commands/extract.md
@@ -102,7 +102,7 @@ To extract only specific resources, pass a YAML filter file with `--filter`. Fil
 apis:
   - echo-api
   - petstore-api
-  - prod-*              # Wildcard: all APIs starting with prod-
+  - 'prod-*'             # Wildcard: all APIs starting with prod-
 products:
   - starter
 backends:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,7 +61,7 @@ Extract only the APIs you care about. Create a `filter.yaml`:
 apiNames:
   - pet-store-api
   - user-api
-  - staging-*           # Wildcard: all APIs starting with staging-
+  - 'staging-*'          # Wildcard: all APIs starting with staging-
 ```
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,9 +58,10 @@ You'll see directories for each resource type — `apis/`, `backends/`, `namedVa
 Extract only the APIs you care about. Create a `filter.yaml`:
 
 ```yaml
-apiNames:
+apis:
   - pet-store-api
   - user-api
+  - staging-*           # Wildcard: all APIs starting with staging-
 ```
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ You'll see directories for each resource type — `apis/`, `backends/`, `namedVa
 Extract only the APIs you care about. Create a `filter.yaml`:
 
 ```yaml
-apis:
+apiNames:
   - pet-store-api
   - user-api
   - staging-*           # Wildcard: all APIs starting with staging-

--- a/docs/guides/filtering-resources.md
+++ b/docs/guides/filtering-resources.md
@@ -155,7 +155,7 @@ workspaces:
   - team-b-workspace              # Simple: extract all resources
 ```
 
-Supported workspace sub-filter keys: `apis`, `backends`, `diagnostics`, `groups`, `loggers`, `namedValues`, `policyFragments`, `products`, `subscriptions`, `tags`, `versionSets`.
+Supported workspace sub-filter keys: `apis`, `backends`, `diagnostics`, `groups`, `loggers`, `namedValues`, `policyFragments`, `products`, `schemas`, `subscriptions`, `tags`, `versionSets`.
 
 ---
 

--- a/docs/guides/filtering-resources.md
+++ b/docs/guides/filtering-resources.md
@@ -140,8 +140,6 @@ apis:
 
 ### Workspace sub-resource filters
 
-> **Note:** Workspace sub-resource filtering is parsed but not yet applied at runtime. Currently, including a workspace extracts all resources within it. This matches the Toolkit's configuration format for forward compatibility. See [#119](https://github.com/Azure/apiops-cli/issues/119) for tracking.
-
 The configuration format supports specifying which workspace-scoped resources to extract:
 
 ```yaml

--- a/docs/guides/filtering-resources.md
+++ b/docs/guides/filtering-resources.md
@@ -72,8 +72,44 @@ namedValues:
 - Simple fields must be an array of strings
 - `apis` and `workspaces` also accept nested object entries for sub-resource filtering (see below)
 - Names are matched case-insensitively against APIM resource names
+- Wildcard patterns are supported — `*` matches any characters, `?` matches a single character (see below)
+- Exact names and wildcard patterns can be mixed in the same array
 - An empty file extracts everything (same as no filter)
 - An empty array (`[]`) excludes ALL resources of that type
+
+---
+
+## Wildcard Pattern Matching
+
+Filter entries support glob-style wildcard patterns for matching multiple resources by naming convention:
+
+| Wildcard | Meaning | Example |
+|----------|---------|---------|
+| `*` | Matches zero or more characters | `prod-*` matches `prod-api`, `prod-users` |
+| `?` | Matches exactly one character | `api-v?` matches `api-v1`, `api-v2` but not `api-v10` |
+
+### Examples
+
+```yaml
+apis:
+  - '*-test'          # All APIs ending with -test
+  - 'prod-*'          # All APIs starting with prod-
+  - '*-internal-*'    # All APIs containing -internal-
+  - 'v2-*-api'        # APIs following v2-{name}-api pattern
+  - 'echo-api'        # Exact names and patterns can be mixed
+
+products:
+  - 'test-*'          # All test products
+  - '*-starter'       # All starter tier products
+
+backends:
+  - 'backend-*-prod'  # All production backends
+
+namedValues:
+  - '*-connection-string'  # All connection string named values
+```
+
+Wildcard matching is case-insensitive, just like exact matching. Special characters in resource names (e.g., dots in `my.api.v1`) are treated literally — `my.api.*` matches `my.api.test` but not `myXapiXtest`.
 
 ---
 
@@ -268,6 +304,20 @@ backends:
 
 There is no "exclude" syntax. To extract everything except certain resources, list all the resources you _do_ want. For large instances, it's often easier to extract everything and use `.gitignore` or separate branches to manage visibility.
 
+### Pattern-Based Team Filtering
+
+Using wildcard patterns to extract resources by naming convention:
+
+```yaml
+# configuration.extractor.yaml
+apis:
+  - 'team-payments-*'     # All APIs owned by the payments team
+namedValues:
+  - 'payments-*'          # All named values for payments
+backends:
+  - '*-payments-*'        # All backends related to payments
+```
+
 ---
 
 ## Tips
@@ -276,6 +326,7 @@ There is no "exclude" syntax. To extract everything except certain resources, li
 - **One filter per team** — In multi-team setups, each team maintains its own `configuration.extractor.yaml`
 - **Commit the filter file** — Keep it in version control alongside your artifacts so CI/CD pipelines can use it
 - **Case-insensitive matching** — Filter values are matched case-insensitively against APIM resource names
+- **Use wildcard patterns** — `*` and `?` patterns let you match resources by naming convention instead of listing each name individually
 - **Validate early** — The config loader validates filter entries and will throw `Failed to load filter config` on invalid YAML. Unknown top-level keys produce a warning.
 
 ---

--- a/src/lib/config-loader.ts
+++ b/src/lib/config-loader.ts
@@ -186,7 +186,7 @@ export async function loadFilterConfig(filePath: string): Promise<FilterConfig |
         if (Object.keys(subFilters).length > 0) {
           config.workspaceSubFilters = {};
           const validWsSubKeys = ['apis', 'backends', 'diagnostics', 'groups', 'loggers',
-            'namedValues', 'policyFragments', 'products', 'subscriptions', 'tags', 'versionSets'] as const;
+            'namedValues', 'policyFragments', 'products', 'schemas', 'subscriptions', 'tags', 'versionSets'] as const;
           for (const [wsName, sf] of Object.entries(subFilters)) {
             const wsSub: WorkspaceSubFilter = {};
             for (const wsField of validWsSubKeys) {

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -44,6 +44,7 @@ export interface WorkspaceSubFilter {
   namedValues?: string[];
   policyFragments?: string[];
   products?: string[];
+  schemas?: string[];
   subscriptions?: string[];
   tags?: string[];
   versionSets?: string[];

--- a/src/services/filter-service.ts
+++ b/src/services/filter-service.ts
@@ -200,11 +200,52 @@ export function extractRootApiName(name: string): string {
 }
 
 /**
+ * Check if a pattern contains wildcard characters (* or ?).
+ */
+export function isWildcardPattern(pattern: string): boolean {
+  return pattern.includes('*') || pattern.includes('?');
+}
+
+/**
+ * Convert a glob-style wildcard pattern to a RegExp.
+ * Supports:
+ *  - `*` matches zero or more characters
+ *  - `?` matches exactly one character
+ * All other characters are escaped for literal matching.
+ * Matching is case-insensitive.
+ */
+export function wildcardToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  const regexStr = escaped.replace(/\*/g, '.*').replace(/\?/g, '.');
+  return new RegExp(`^${regexStr}$`, 'i');
+}
+
+/** Warn once per pattern that looks likely to cause slow matching. */
+const warnedPatterns = new Set<string>();
+
+/**
+ * Match a string against a glob-style wildcard pattern (case-insensitive).
+ * Logs a warning for patterns with many wildcards that may be slow.
+ */
+export function wildcardMatch(pattern: string, text: string): boolean {
+  const starCount = (pattern.match(/\*/g) ?? []).length;
+  if (starCount > 4 && !warnedPatterns.has(pattern)) {
+    warnedPatterns.add(pattern);
+    logger.warn(
+      `Filter pattern "${pattern}" has ${starCount} wildcards and may be slow to evaluate`
+    );
+  }
+  return wildcardToRegex(pattern).test(text);
+}
+
+/**
  * Match a resource name against a filter allowlist.
  *
  * - undefined allowlist → include all (no filter for this type)
  * - empty array → include none
- * - non-empty array → case-insensitive match
+ * - non-empty array → case-insensitive exact match or wildcard pattern match
+ *
+ * Wildcard patterns use `*` (zero or more characters) and `?` (single character).
  */
 function matchesFilter(name: string, allowlist: string[] | undefined): boolean {
   if (allowlist === undefined) {
@@ -220,6 +261,9 @@ function matchesFilter(name: string, allowlist: string[] | undefined): boolean {
   const lowerRoot = extractRootApiName(lowerName);
 
   return allowlist.some((allowed) => {
+    if (isWildcardPattern(allowed)) {
+      return wildcardMatch(allowed, lowerName) || wildcardMatch(allowed, lowerRoot);
+    }
     const lowerAllowed = allowed.toLowerCase();
     return lowerName === lowerAllowed || lowerRoot === lowerAllowed;
   });

--- a/src/services/workspace-extractor.ts
+++ b/src/services/workspace-extractor.ts
@@ -71,6 +71,16 @@ export async function extractWorkspaces(
             : pattern.toLowerCase() === name.toLowerCase()
         )
       );
+
+      // Warn about exact (non-wildcard) entries that didn't match any discovered workspace
+      for (const entry of filter.workspaces) {
+        if (!isWildcardPattern(entry)) {
+          const matched = discovered.some((d) => d.toLowerCase() === entry.toLowerCase());
+          if (!matched) {
+            logger.warn(`Workspace filter entry "${entry}" did not match any discovered workspace`);
+          }
+        }
+      }
     } else {
       workspaceNames = filter.workspaces;
     }

--- a/src/services/workspace-extractor.ts
+++ b/src/services/workspace-extractor.ts
@@ -297,6 +297,7 @@ function workspaceSubFilterToFilterConfig(sub: WorkspaceSubFilter): FilterConfig
     namedValues: sub.namedValues,
     policyFragments: sub.policyFragments,
     products: sub.products,
+    schemas: sub.schemas,
     subscriptions: sub.subscriptions,
     tags: sub.tags,
     versionSets: sub.versionSets,

--- a/src/services/workspace-extractor.ts
+++ b/src/services/workspace-extractor.ts
@@ -9,12 +9,13 @@ import { IApimClient } from '../clients/iapim-client.js';
 import { IArtifactStore } from '../clients/iartifact-store.js';
 import { ApimServiceContext } from '../models/types.js';
 import { ResourceType, RESOURCE_TYPE_METADATA } from '../models/resource-types.js';
-import { FilterConfig } from '../models/config.js';
+import { FilterConfig, WorkspaceSubFilter } from '../models/config.js';
 import { extractResourceType, ExtractedResource } from './resource-extractor.js';
 import { extractApiResources, extractWorkspaceApiTags } from './api-extractor.js';
 import { extractProductResources, extractWorkspaceProductTags } from './product-extractor.js';
 import { logger } from '../lib/logger.js';
 import { getNamePart } from '../lib/resource-path.js';
+import { isWildcardPattern, wildcardMatch } from './filter-service.js';
 
 /**
  * Types that can exist at the workspace level, derived from RESOURCE_TYPE_METADATA.
@@ -58,17 +59,24 @@ export async function extractWorkspaces(
       logger.debug('Workspace filter is empty array — excluding all workspaces');
       return results;
     }
-    workspaceNames = filter.workspaces;
+
+    const hasWildcards = filter.workspaces.some(isWildcardPattern);
+    if (hasWildcards) {
+      // Wildcard patterns require discovery so we can match against real names
+      const discovered = await discoverWorkspaceNames(client, context);
+      workspaceNames = discovered.filter((name) =>
+        filter.workspaces!.some((pattern) =>
+          isWildcardPattern(pattern)
+            ? wildcardMatch(pattern, name)
+            : pattern.toLowerCase() === name.toLowerCase()
+        )
+      );
+    } else {
+      workspaceNames = filter.workspaces;
+    }
   } else {
     // No workspace filter defined — discover all workspaces
-    const discovered: string[] = [];
-    for await (const item of client.listResources(context, ResourceType.Workspace)) {
-      const name = item['name'];
-      if (typeof name === 'string') {
-        discovered.push(name);
-      }
-    }
-    workspaceNames = discovered;
+    workspaceNames = await discoverWorkspaceNames(client, context);
   }
 
   if (workspaceNames.length === 0) {
@@ -92,7 +100,8 @@ export async function extractWorkspaces(
     }
 
     const wsResult = await extractWorkspace(
-      client, store, context, wsName, outputDir, filter
+      client, store, context, wsName, outputDir,
+      resolveWorkspaceFilter(wsName, filter)
     );
     results.push(wsResult);
   }
@@ -217,4 +226,69 @@ async function extractWorkspace(
   logger.info(`Workspace "${workspaceName}": extracted ${resourceCount} resources, ${errorCount} errors`);
 
   return { workspaceName, resourceCount, errorCount };
+}
+
+/**
+ * Discover all workspace names from APIM.
+ */
+async function discoverWorkspaceNames(
+  client: IApimClient,
+  context: ApimServiceContext
+): Promise<string[]> {
+  const names: string[] = [];
+  for await (const item of client.listResources(context, ResourceType.Workspace)) {
+    const name = item['name'];
+    if (typeof name === 'string') {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Resolve the effective FilterConfig for a workspace.
+ * If the workspace has a sub-filter in workspaceSubFilters, convert it to a FilterConfig.
+ * Otherwise return undefined (no filter = extract everything in the workspace).
+ */
+export function resolveWorkspaceFilter(
+  workspaceName: string,
+  filter?: FilterConfig
+): FilterConfig | undefined {
+  if (!filter?.workspaceSubFilters) {
+    return undefined;
+  }
+
+  // Case-insensitive lookup of workspace sub-filter
+  const lowerName = workspaceName.toLowerCase();
+  const matchingKey = Object.keys(filter.workspaceSubFilters).find(
+    (k) => k.toLowerCase() === lowerName
+  );
+
+  if (!matchingKey) {
+    return undefined;
+  }
+
+  const sub = filter.workspaceSubFilters[matchingKey];
+  return workspaceSubFilterToFilterConfig(sub);
+}
+
+/**
+ * Convert a WorkspaceSubFilter to a FilterConfig so the standard
+ * filter-service matching logic can be applied to workspace-scoped resources.
+ */
+function workspaceSubFilterToFilterConfig(sub: WorkspaceSubFilter): FilterConfig {
+  return {
+    apis: sub.apis,
+    apiSubFilters: sub.apiSubFilters,
+    backends: sub.backends,
+    diagnostics: sub.diagnostics,
+    groups: sub.groups,
+    loggers: sub.loggers,
+    namedValues: sub.namedValues,
+    policyFragments: sub.policyFragments,
+    products: sub.products,
+    subscriptions: sub.subscriptions,
+    tags: sub.tags,
+    versionSets: sub.versionSets,
+  };
 }

--- a/src/templates/configs/filter-config.ts
+++ b/src/templates/configs/filter-config.ts
@@ -15,8 +15,8 @@ export function generateFilterConfig(): string {
 # apis:
 #   - echo-api
 #   - petstore-api
-#   - prod-*                        # Wildcard: all APIs starting with prod-
-#   - *-internal-*                  # Wildcard: all APIs containing -internal-
+#   - 'prod-*'                       # Wildcard: all APIs starting with prod-
+#   - '*-internal-*'                 # Wildcard: all APIs containing -internal-
 
 # Advanced: Filter API sub-resources (operations, diagnostics, schemas, releases)
 # apis:
@@ -25,7 +25,7 @@ export function generateFilterConfig(): string {
 #       operations:
 #         - get-pets
 #         - create-pet
-#         - list-*                    # Wildcard: all operations starting with list-
+#         - 'list-*'                  # Wildcard: all operations starting with list-
 #       diagnostics:
 #         - applicationinsights
 #       schemas: []                   # Exclude all schemas

--- a/src/templates/configs/filter-config.ts
+++ b/src/templates/configs/filter-config.ts
@@ -11,10 +11,12 @@ export function generateFilterConfig(): string {
 # For full format details and examples, see:
 # https://github.com/Azure/apiops-cli/blob/main/docs/guides/filtering-resources.md
 
-# Extract only specific APIs by name
+# Extract only specific APIs by name (or wildcard pattern)
 # apis:
 #   - echo-api
 #   - petstore-api
+#   - prod-*                        # Wildcard: all APIs starting with prod-
+#   - *-internal-*                  # Wildcard: all APIs containing -internal-
 
 # Advanced: Filter API sub-resources (operations, diagnostics, schemas, releases)
 # apis:
@@ -23,6 +25,7 @@ export function generateFilterConfig(): string {
 #       operations:
 #         - get-pets
 #         - create-pet
+#         - list-*                    # Wildcard: all operations starting with list-
 #       diagnostics:
 #         - applicationinsights
 #       schemas: []                   # Exclude all schemas
@@ -116,5 +119,9 @@ export function generateFilterConfig(): string {
 #   Example:
 #   gateways: []
 #   subscriptions: []
+# - Use * to match any characters: prod-* matches prod-api, prod-users
+# - Use ? to match a single character: api-v? matches api-v1, api-v2
+# - Exact names and wildcard patterns can be mixed in the same list
+# - All matching is case-insensitive
 `;
 }

--- a/tests/unit/services/filter-service.test.ts
+++ b/tests/unit/services/filter-service.test.ts
@@ -12,6 +12,9 @@ import {
   shouldIncludeResource,
   filterResources,
   extractRootApiName,
+  isWildcardPattern,
+  wildcardToRegex,
+  wildcardMatch,
 } from '../../../src/services/filter-service.js';
 
 describe('filter-service', () => {
@@ -323,6 +326,261 @@ describe('filter-service', () => {
 
     it('should handle empty string', () => {
       expect(extractRootApiName('')).toBe('');
+    });
+  });
+
+  describe('isWildcardPattern', () => {
+    it('should detect * wildcard', () => {
+      expect(isWildcardPattern('*-test')).toBe(true);
+      expect(isWildcardPattern('prod-*')).toBe(true);
+      expect(isWildcardPattern('*')).toBe(true);
+    });
+
+    it('should detect ? wildcard', () => {
+      expect(isWildcardPattern('api-v?')).toBe(true);
+      expect(isWildcardPattern('?-test')).toBe(true);
+    });
+
+    it('should return false for exact names', () => {
+      expect(isWildcardPattern('my-api')).toBe(false);
+      expect(isWildcardPattern('prod-api-v2')).toBe(false);
+    });
+  });
+
+  describe('wildcardMatch', () => {
+    it('should match * against any characters', () => {
+      expect(wildcardMatch('prod-*', 'prod-api')).toBe(true);
+      expect(wildcardMatch('prod-*', 'prod-')).toBe(true);
+      expect(wildcardMatch('prod-*', 'dev-api')).toBe(false);
+    });
+
+    it('should match ? against a single character', () => {
+      expect(wildcardMatch('api-v?', 'api-v1')).toBe(true);
+      expect(wildcardMatch('api-v?', 'api-v2')).toBe(true);
+      expect(wildcardMatch('api-v?', 'api-v10')).toBe(false);
+      expect(wildcardMatch('api-v?', 'api-v')).toBe(false);
+    });
+
+    it('should treat dots in patterns as literal dots, not regex any-char', () => {
+      // "myapi.*" should match "myapi.test" but NOT "myapixtest"
+      expect(wildcardMatch('myapi.*', 'myapi.test')).toBe(true);
+      expect(wildcardMatch('myapi.*', 'myapi.v2')).toBe(true);
+      expect(wildcardMatch('myapi.*', 'myapixtest')).toBe(false);
+      expect(wildcardMatch('myapi.*', 'myapi-test')).toBe(false);
+    });
+
+    it('should handle names with dots when matching exact segments', () => {
+      // "*.test" should match "echo.test" but not "echo-test"
+      expect(wildcardMatch('*.test', 'echo.test')).toBe(true);
+      expect(wildcardMatch('*.test', 'petstore.test')).toBe(true);
+      expect(wildcardMatch('*.test', 'echo-test')).toBe(false);
+      expect(wildcardMatch('*.test', 'echoXtest')).toBe(false);
+    });
+
+    it('should handle names with multiple dots', () => {
+      expect(wildcardMatch('api.v1.*', 'api.v1.test')).toBe(true);
+      expect(wildcardMatch('api.v1.*', 'api.v1.prod')).toBe(true);
+      expect(wildcardMatch('api.v1.*', 'api.v2.test')).toBe(false);
+      expect(wildcardMatch('*.v1.*', 'api.v1.test')).toBe(true);
+      expect(wildcardMatch('*.v1.*', 'svc.v1.prod')).toBe(true);
+    });
+
+    it('should treat other regex special chars as literals', () => {
+      // Names with parentheses, brackets, plus, etc.
+      expect(wildcardMatch('api(v1)*', 'api(v1)-test')).toBe(true);
+      expect(wildcardMatch('api[1]*', 'api[1]-prod')).toBe(true);
+      expect(wildcardMatch('api+v1*', 'api+v1-test')).toBe(true);
+    });
+
+    it('should be case-insensitive', () => {
+      expect(wildcardMatch('Prod-*', 'prod-api')).toBe(true);
+      expect(wildcardMatch('Prod-*', 'PROD-API')).toBe(true);
+    });
+  });
+
+  describe('wildcardToRegex', () => {
+    it('should produce a regex that anchors to start and end', () => {
+      const regex = wildcardToRegex('prod-*');
+      expect(regex.test('prod-api')).toBe(true);
+      expect(regex.test('xxprod-api')).toBe(false);
+    });
+
+    it('should escape regex special characters', () => {
+      const regex = wildcardToRegex('api.v1.*');
+      expect(regex.test('api.v1.test')).toBe(true);
+      expect(regex.test('apixv1xtest')).toBe(false);
+    });
+  });
+
+  describe('wildcard pattern matching in shouldIncludeResource', () => {
+    it('should match APIs ending with a suffix using *-suffix pattern', () => {
+      const filter: FilterConfig = { apis: ['*-test'] };
+      const included: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['echo-test'],
+      };
+      const excluded: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['echo-prod'],
+      };
+      expect(shouldIncludeResource(included, filter)).toBe(true);
+      expect(shouldIncludeResource(excluded, filter)).toBe(false);
+    });
+
+    it('should match APIs starting with a prefix using prefix-* pattern', () => {
+      const filter: FilterConfig = { apis: ['prod-*'] };
+      const included: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['prod-users-api'],
+      };
+      const excluded: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['dev-users-api'],
+      };
+      expect(shouldIncludeResource(included, filter)).toBe(true);
+      expect(shouldIncludeResource(excluded, filter)).toBe(false);
+    });
+
+    it('should match APIs containing a substring using *-substr-* pattern', () => {
+      const filter: FilterConfig = { apis: ['*-internal-*'] };
+      const included: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['company-internal-users'],
+      };
+      const excluded: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['company-external-users'],
+      };
+      expect(shouldIncludeResource(included, filter)).toBe(true);
+      expect(shouldIncludeResource(excluded, filter)).toBe(false);
+    });
+
+    it('should match all resources with * wildcard', () => {
+      const filter: FilterConfig = { apis: ['*'] };
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['any-api-name'],
+      };
+      expect(shouldIncludeResource(descriptor, filter)).toBe(true);
+    });
+
+    it('should support ? for single character matching', () => {
+      const filter: FilterConfig = { apis: ['api-v?'] };
+      const v1: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['api-v1'],
+      };
+      const v2: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['api-v2'],
+      };
+      const v10: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['api-v10'],
+      };
+      expect(shouldIncludeResource(v1, filter)).toBe(true);
+      expect(shouldIncludeResource(v2, filter)).toBe(true);
+      expect(shouldIncludeResource(v10, filter)).toBe(false);
+    });
+
+    it('should support mixing exact names and wildcard patterns', () => {
+      const filter: FilterConfig = { apis: ['echo-api', 'prod-*'] };
+      const exact: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['echo-api'],
+      };
+      const pattern: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['prod-users'],
+      };
+      const neither: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['dev-users'],
+      };
+      expect(shouldIncludeResource(exact, filter)).toBe(true);
+      expect(shouldIncludeResource(pattern, filter)).toBe(true);
+      expect(shouldIncludeResource(neither, filter)).toBe(false);
+    });
+
+    it('should apply wildcard matching case-insensitively', () => {
+      const filter: FilterConfig = { apis: ['Prod-*'] };
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['PROD-Users-Api'],
+      };
+      expect(shouldIncludeResource(descriptor, filter)).toBe(true);
+    });
+
+    it('should apply wildcard matching to non-API resource types', () => {
+      const filter: FilterConfig = {
+        backends: ['backend-*-prod'],
+        products: ['test-*'],
+        namedValues: ['*-secret'],
+      };
+      const backend: ResourceDescriptor = {
+        type: ResourceType.Backend,
+        nameParts: ['backend-users-prod'],
+      };
+      const product: ResourceDescriptor = {
+        type: ResourceType.Product,
+        nameParts: ['test-starter'],
+      };
+      const namedValue: ResourceDescriptor = {
+        type: ResourceType.NamedValue,
+        nameParts: ['db-connection-secret'],
+      };
+      const excludedBackend: ResourceDescriptor = {
+        type: ResourceType.Backend,
+        nameParts: ['backend-users-dev'],
+      };
+      expect(shouldIncludeResource(backend, filter)).toBe(true);
+      expect(shouldIncludeResource(product, filter)).toBe(true);
+      expect(shouldIncludeResource(namedValue, filter)).toBe(true);
+      expect(shouldIncludeResource(excludedBackend, filter)).toBe(false);
+    });
+
+    it('should apply wildcard matching to API revisions by root name', () => {
+      const filter: FilterConfig = { apis: ['prod-*'] };
+      const descriptor: ResourceDescriptor = {
+        type: ResourceType.Api,
+        nameParts: ['prod-users;rev=3'],
+      };
+      expect(shouldIncludeResource(descriptor, filter)).toBe(true);
+    });
+
+    it('should apply wildcard matching to child resources via parent name', () => {
+      const filter: FilterConfig = { apis: ['prod-*'] };
+      const apiPolicy: ResourceDescriptor = {
+        type: ResourceType.ApiPolicy,
+        nameParts: ['prod-users'],
+      };
+      const excludedPolicy: ResourceDescriptor = {
+        type: ResourceType.ApiPolicy,
+        nameParts: ['dev-users'],
+      };
+      expect(shouldIncludeResource(apiPolicy, filter)).toBe(true);
+      expect(shouldIncludeResource(excludedPolicy, filter)).toBe(false);
+    });
+
+    it('should apply wildcard matching in apiSubFilters operations', () => {
+      const filter: FilterConfig = {
+        apis: ['my-api'],
+        apiSubFilters: {
+          'my-api': {
+            operations: ['get-*'],
+          },
+        },
+      };
+      const included: ResourceDescriptor = {
+        type: ResourceType.ApiOperation,
+        nameParts: ['my-api', 'get-users'],
+      };
+      const excluded: ResourceDescriptor = {
+        type: ResourceType.ApiOperation,
+        nameParts: ['my-api', 'post-users'],
+      };
+      expect(shouldIncludeResource(included, filter)).toBe(true);
+      expect(shouldIncludeResource(excluded, filter)).toBe(false);
     });
   });
 });

--- a/tests/unit/services/workspace-extractor.test.ts
+++ b/tests/unit/services/workspace-extractor.test.ts
@@ -9,6 +9,7 @@ import { ResourceType } from '../../../src/models/resource-types.js';
 import { ApimServiceContext } from '../../../src/models/types.js';
 import { FilterConfig } from '../../../src/models/config.js';
 import { extractWorkspaces } from '../../../src/services/workspace-extractor.js';
+import { resolveWorkspaceFilter } from '../../../src/services/workspace-extractor.js';
 
 const testContext: ApimServiceContext = {
   subscriptionId: 'sub-1',
@@ -201,6 +202,189 @@ describe('workspace-extractor', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0]?.resourceCount).toBeGreaterThan(0);
+    });
+
+    it('should apply workspace sub-filter to limit extracted resources', async () => {
+      const client = createMockClient();
+      const listedTypes: ResourceType[] = [];
+      client.listResources = async function* (_ctx: ApimServiceContext, type: ResourceType) {
+        listedTypes.push(type);
+        if (type === ResourceType.NamedValue) {
+          yield { name: 'ws-nv-1', properties: {} };
+          yield { name: 'ws-nv-2', properties: {} };
+        }
+      };
+      const store = createMockStore();
+      const filter: FilterConfig = {
+        workspaces: ['ws-1'],
+        workspaceSubFilters: {
+          'ws-1': {
+            namedValues: ['ws-nv-1'],
+          },
+        },
+      };
+
+      const results = await extractWorkspaces(
+        client, store, testContext, '/output', filter
+      );
+
+      expect(results).toHaveLength(1);
+      // Only ws-nv-1 should be extracted, ws-nv-2 should be filtered out
+      expect(results[0]?.resourceCount).toBe(1);
+    });
+
+    it('should extract everything when workspace has no sub-filter', async () => {
+      const client = createMockClient();
+      client.listResources = async function* (_ctx: ApimServiceContext, type: ResourceType) {
+        if (type === ResourceType.NamedValue) {
+          yield { name: 'ws-nv-1', properties: {} };
+          yield { name: 'ws-nv-2', properties: {} };
+        }
+      };
+      const store = createMockStore();
+      const filter: FilterConfig = {
+        workspaces: ['ws-1'],
+        // No workspaceSubFilters — extract everything in the workspace
+      };
+
+      const results = await extractWorkspaces(
+        client, store, testContext, '/output', filter
+      );
+
+      expect(results).toHaveLength(1);
+      // Both named values should be extracted
+      expect(results[0]?.resourceCount).toBe(2);
+    });
+
+    it('should support wildcard patterns in workspace names', async () => {
+      const client = createMockClient();
+      // Discovery returns three workspaces
+      const originalListResources = client.listResources;
+      let firstCall = true;
+      client.listResources = async function* (ctx: ApimServiceContext, type: ResourceType) {
+        if (type === ResourceType.Workspace && firstCall) {
+          firstCall = false;
+          yield { name: 'team-a-workspace', properties: {} };
+          yield { name: 'team-b-workspace', properties: {} };
+          yield { name: 'other-workspace', properties: {} };
+          return;
+        }
+        yield* originalListResources(ctx, type);
+      };
+      const store = createMockStore();
+      const filter: FilterConfig = { workspaces: ['team-*'] };
+
+      const results = await extractWorkspaces(
+        client, store, testContext, '/output', filter
+      );
+
+      // Only team-a-workspace and team-b-workspace should match
+      expect(results).toHaveLength(2);
+      expect(results.map((r) => r.workspaceName).sort()).toEqual([
+        'team-a-workspace',
+        'team-b-workspace',
+      ]);
+    });
+
+    it('should apply sub-filter with wildcard workspace name patterns', async () => {
+      const client = createMockClient();
+      let firstCall = true;
+      client.listResources = async function* (_ctx: ApimServiceContext, type: ResourceType) {
+        if (type === ResourceType.Workspace && firstCall) {
+          firstCall = false;
+          yield { name: 'team-a', properties: {} };
+          return;
+        }
+        if (type === ResourceType.NamedValue) {
+          yield { name: 'nv-1', properties: {} };
+          yield { name: 'nv-2', properties: {} };
+        }
+      };
+      const store = createMockStore();
+      const filter: FilterConfig = {
+        workspaces: ['team-*'],
+        workspaceSubFilters: {
+          'team-a': {
+            namedValues: ['nv-1'],
+          },
+        },
+      };
+
+      const results = await extractWorkspaces(
+        client, store, testContext, '/output', filter
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.workspaceName).toBe('team-a');
+      // Only nv-1 should be extracted due to sub-filter
+      expect(results[0]?.resourceCount).toBe(1);
+    });
+  });
+
+  describe('resolveWorkspaceFilter', () => {
+    it('should return undefined when no filter provided', () => {
+      expect(resolveWorkspaceFilter('ws-1')).toBeUndefined();
+    });
+
+    it('should return undefined when no workspaceSubFilters', () => {
+      const filter: FilterConfig = { workspaces: ['ws-1'] };
+      expect(resolveWorkspaceFilter('ws-1', filter)).toBeUndefined();
+    });
+
+    it('should return undefined when workspace not in sub-filters', () => {
+      const filter: FilterConfig = {
+        workspaces: ['ws-1'],
+        workspaceSubFilters: {
+          'ws-2': { apis: ['api-1'] },
+        },
+      };
+      expect(resolveWorkspaceFilter('ws-1', filter)).toBeUndefined();
+    });
+
+    it('should resolve workspace sub-filter case-insensitively', () => {
+      const filter: FilterConfig = {
+        workspaces: ['WS-1'],
+        workspaceSubFilters: {
+          'ws-1': { apis: ['api-1'], backends: ['backend-1'] },
+        },
+      };
+      const result = resolveWorkspaceFilter('WS-1', filter);
+      expect(result).toBeDefined();
+      expect(result!.apis).toEqual(['api-1']);
+      expect(result!.backends).toEqual(['backend-1']);
+    });
+
+    it('should convert all workspace sub-filter fields to FilterConfig', () => {
+      const filter: FilterConfig = {
+        workspaceSubFilters: {
+          'ws-1': {
+            apis: ['api-1'],
+            backends: ['be-1'],
+            diagnostics: ['diag-1'],
+            groups: ['group-1'],
+            loggers: ['logger-1'],
+            namedValues: ['nv-1'],
+            policyFragments: ['pf-1'],
+            products: ['prod-1'],
+            subscriptions: ['sub-1'],
+            tags: ['tag-1'],
+            versionSets: ['vs-1'],
+          },
+        },
+      };
+      const result = resolveWorkspaceFilter('ws-1', filter);
+      expect(result).toBeDefined();
+      expect(result!.apis).toEqual(['api-1']);
+      expect(result!.backends).toEqual(['be-1']);
+      expect(result!.diagnostics).toEqual(['diag-1']);
+      expect(result!.groups).toEqual(['group-1']);
+      expect(result!.loggers).toEqual(['logger-1']);
+      expect(result!.namedValues).toEqual(['nv-1']);
+      expect(result!.policyFragments).toEqual(['pf-1']);
+      expect(result!.products).toEqual(['prod-1']);
+      expect(result!.subscriptions).toEqual(['sub-1']);
+      expect(result!.tags).toEqual(['tag-1']);
+      expect(result!.versionSets).toEqual(['vs-1']);
     });
   });
 });

--- a/tests/unit/services/workspace-extractor.test.ts
+++ b/tests/unit/services/workspace-extractor.test.ts
@@ -206,9 +206,7 @@ describe('workspace-extractor', () => {
 
     it('should apply workspace sub-filter to limit extracted resources', async () => {
       const client = createMockClient();
-      const listedTypes: ResourceType[] = [];
       client.listResources = async function* (_ctx: ApimServiceContext, type: ResourceType) {
-        listedTypes.push(type);
         if (type === ResourceType.NamedValue) {
           yield { name: 'ws-nv-1', properties: {} };
           yield { name: 'ws-nv-2', properties: {} };


### PR DESCRIPTION
## Summary

Adds glob-style wildcard pattern matching (`*` and `?`) to all name-based filter configuration fields, and implements workspace sub-resource filtering so nested workspace filters are applied at runtime.

## Changes

### Wildcard Pattern Matching — `src/services/filter-service.ts`
- Added `isWildcardPattern()` — detects whether a filter entry contains `*` or `?` wildcards
- Added `wildcardToRegex()` — converts glob patterns to anchored, case-insensitive RegExp with proper escaping of all regex metacharacters (`. + ^ $ { } ( ) | [ ] \`)
- Added `wildcardMatch()` — performs the match with a warning for patterns containing >4 wildcards that may be slow
- Updated `matchesFilter()` to use wildcard matching when patterns are detected, falling back to exact matching for plain names

### Workspace Sub-Resource Filtering — `src/services/workspace-extractor.ts`
- Added `resolveWorkspaceFilter()` — looks up `WorkspaceSubFilter` by workspace name (case-insensitive) and converts it to a `FilterConfig`
- Added `workspaceSubFilterToFilterConfig()` — maps all 12 workspace sub-filter fields (including `schemas`) to the standard `FilterConfig` interface
- Added `discoverWorkspaceNames()` — extracted workspace discovery into a reusable helper
- Wildcard patterns in `workspaces` filter now trigger discovery-then-filter instead of using patterns as literal workspace names
- Warns when exact (non-wildcard) workspace entries don't match any discovered workspace

### Workspace Schemas Support — `src/models/config.ts`, `src/lib/config-loader.ts`
- Added `schemas` field to `WorkspaceSubFilter` interface — `GlobalSchema` is workspace-supported but was previously missing from the sub-filter model
- Added `schemas` to config loader's `validWsSubKeys` so it's accepted in YAML

### Tests
- **`tests/unit/services/filter-service.test.ts`** — 17 new tests: wildcard suffix/prefix/contains/match-all patterns, `?` single-char matching, mixed exact+wildcard lists, case-insensitivity, dots and special chars as literals, API revisions with wildcards, child resources, apiSubFilter operations
- **`tests/unit/services/workspace-extractor.test.ts`** — 8 new tests: workspace sub-filter application, wildcard workspace names, case-insensitive sub-filter lookup, full field mapping, combined wildcard names + sub-filters

### Documentation & Templates
- **`docs/guides/filtering-resources.md`** — Added "Wildcard Pattern Matching" section with syntax table and examples; added pattern-based team filtering common pattern; updated rules and tips; removed "not yet implemented" warning from workspace sub-resource filtering; added `schemas` to workspace sub-filter keys list
- **`docs/commands/extract.md`** — Added wildcard examples to filter configuration section
- **`docs/getting-started.md`** — Added wildcard example to quickstart filter
- **`src/templates/configs/filter-config.ts`** — Added wildcard examples with proper YAML quoting and syntax documentation to the generated `configuration.extractor.yaml` template

## Example Usage

```yaml
# Wildcard patterns (quote patterns starting with *)
apis:
  - '*-test'          # Match all APIs ending with -test
  - 'prod-*'          # Match all APIs starting with prod-
  - 'api-v?'          # Match api-v1, api-v2, etc.
  - echo-api          # Exact match still works

backends:
  - 'backend-*-prod'

# Workspace sub-resource filtering (now applied at runtime)
workspaces:
  - team-workspace:
      apis:
        - 'team-api-*'
      backends:
        - team-backend
      namedValues:
        - 'team-*-key'
      schemas:
        - 'team-schema-*'
```

## Related Issue(s)

Closes #48
Closes #119