### PR TITLE
fix: remove APIOps Toolkit reference and secret value from template override

### DIFF
--- a/src/templates/configs/override-config.ts
+++ b/src/templates/configs/override-config.ts
@@ -8,7 +8,6 @@
 export function generateOverrideConfig(environment: string): string {
   return `# APIM Override Configuration for ${environment} environment
 # Customize resource properties for this specific environment
-# All APIOps Toolkit override sections are supported.
 # For full format details and examples, see:
 # https://github.com/Azure/apiops-cli/blob/main/docs/guides/environment-overrides.md
 
@@ -19,7 +18,7 @@ export function generateOverrideConfig(environment: string): string {
 #       value: "${environment}-api-key-value"
 #   - name: connection-string
 #     properties:
-#       value: "Server=${environment}-db.example.com;Database=mydb"
+#       value: "{#[DB_Connection_String]#}"
 #   - name: secret-from-keyvault
 #     properties:
 #       keyVault:

--- a/tests/unit/templates/configs/config-templates.test.ts
+++ b/tests/unit/templates/configs/config-templates.test.ts
@@ -82,7 +82,7 @@ describe('configs/override-config', () => {
     it('should include environment name in examples', () => {
       const config = generateOverrideConfig('production');
       expect(config).toContain('production-api-key-value');
-      expect(config).toContain('production-db.example.com');
+      expect(config).toContain('{#[DB_Connection_String]#}');
       expect(config).toContain('production-kv.vault.azure.net');
     });
 


### PR DESCRIPTION
## Summary

Removes the "APIOps Toolkit" reference and replaces the example secret value in the override configuration template generated by `apiops init`.

## Changes

- **Removed "APIOps Toolkit" comment** — The line `# All APIOps Toolkit override sections are supported.` was removed entirely as it doesn't add useful information and may confuse customers unfamiliar with the toolkit.
- **Replaced secret example with token placeholder** — Changed the connection string example from `"Server=${environment}-db.example.com;Database=mydb"` to `"{#[DB_Connection_String]#}"` which aligns with the pipeline token substitution format and avoids setting a precedent of hardcoding secrets.
- **Updated test** — Adjusted the corresponding test assertion to match the new placeholder.

## Related Issue(s)

Closes #154