### PR TITLE
fix: harden integration-test workflow (remove artifact upload, upgrade actions)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -101,9 +101,9 @@ jobs:
     environment: integration-test # Requires approval for cost protection
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -128,7 +128,7 @@ jobs:
           "skuName=$skuName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -154,7 +154,7 @@ jobs:
 
       - name: Azure Login - Refresh Before Phase 2
         if: success()
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           # Phase 1 can run for a long time while APIM activates; refresh login
           # before extract/publish so apiops receives a fresh federated session.
@@ -231,14 +231,6 @@ jobs:
             -TargetResourceGroup '${{ steps.phase1.outputs.targetResourceGroup }}' `
             -TargetApimName '${{ steps.phase1.outputs.targetApimName }}' `
             -LogLevel '${{ steps.settings.outputs.logLevel }}'
-
-      - name: Upload Extracted Artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: extracted-artifacts-${{ steps.phase1.outputs.skuName }}
-          path: ${{ steps.phase2.outputs.ExtractOutputDir || './extracted-artifacts/' }}
-          if-no-files-found: ignore
 
       - name: Run Round-Trip Phase 7 (Teardown)
         if: always()


### PR DESCRIPTION
## Motivation

The "Test: Extract->Publish Round-Trip" workflow ([run #27776806123](https://github.com/Azure/apiops-cli/actions/runs/27776806123)) had two issues:

1. **Security** -- The "Upload Extracted Artifacts" step published extracted APIM artifacts that contain subscription ID information, which should not be publicly visible.
2. **Deprecation warning** -- All four actions (`actions/checkout@v4`, `actions/setup-node@v4`, `actions/upload-artifact@v4`, `azure/login@v2`) target Node.js 20, which is deprecated and being forced to run on Node.js 24.

## Approach

- Removed the `upload-artifact` step entirely. The extracted artifacts are only needed within the workflow run itself and should never be persisted as downloadable artifacts.
- Upgraded the remaining actions to their Node.js 24-compatible versions:
  - `actions/checkout@v4` -> `@v6`
  - `actions/setup-node@v4` -> `@v5`
  - `azure/login@v2` -> `@v3`

## Notes

- No functional changes to the test logic itself -- all seven phases still run in the same order.
- The `upload-artifact` removal also eliminates one of the four deprecation-triggering actions, so we only needed to upgrade the remaining three.