### PR TITLE
fix: preserve meaningful segment in resource group log masking

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -87,8 +87,8 @@ concurrency:
   cancel-in-progress: false # Don't cancel — would leave resources running
 
 env:
-  SOURCE_RG: rg-apiops-bvt-source-${{ github.run_id }}
-  TARGET_RG: rg-apiops-bvt-target-${{ github.run_id }}
+  SOURCE_RG: rg-apiops-bvt-src-${{ github.run_id }}
+  TARGET_RG: rg-apiops-bvt-tgt-${{ github.run_id }}
   SOURCE_APIM: apiops-bvt-src-${{ github.run_id }}
   TARGET_APIM: apiops-bvt-tgt-${{ github.run_id }}
 

--- a/tests/integration/all-resource-types/modules/LogMasking.psm1
+++ b/tests/integration/all-resource-types/modules/LogMasking.psm1
@@ -105,6 +105,16 @@ function Protect-ResourceGroupName {
         return "$($Matches[1])-...-$($Matches[2])-$($Matches[3])-rg"
     }
 
+    # When the name ends with a numeric suffix (≥6 digits, such as a GitHub run_id
+    # or timestamp), preserve the last meaningful dash-segment before the number so
+    # logs stay distinguishable.
+    if ($Value -match '^(.+)-([a-zA-Z][a-zA-Z0-9]*)-(\d{6,})$') {
+        $prefixPart = $Matches[1]
+        $keepLen = [Math]::Min(3, $prefixPart.Length)
+        $ellipsis = if ($keepLen -lt $prefixPart.Length) { '...' } else { '' }
+        return "$($prefixPart.Substring(0, $keepLen))$ellipsis$($Matches[2])-$($Matches[3])"
+    }
+
     return Protect-Identifier -Value $Value -Prefix 3 -Suffix 7
 }
 


### PR DESCRIPTION
## Motivation

When the integration test pipeline creates resource groups like `rg-apiops-bvt-source-<run_id>`, the `Protect-ResourceGroupName` function truncates them using a generic prefix/suffix strategy, producing output like `rg-...1553476`. This loses the meaningful `source`/`target` segment, making it hard to distinguish source and target RGs in log output.

## Approach

**Shorten RG env var names** in the workflow to use `src`/`tgt` instead of `source`/`target`, matching the existing APIM naming convention (`apiops-bvt-src-*` / `apiops-bvt-tgt-*`).

**Add smart truncation** in `Protect-ResourceGroupName` that detects resource group names ending with a long numeric suffix (>=6 digits, typical of GitHub `run_id` values or timestamps). When matched, the last meaningful dash-separated segment before the number is preserved -- for example `rg-...src-27781553476` instead of the previous `rg-...1553476`. Names that don't end with a numeric suffix continue to use the existing `Protect-Identifier` fallback, so there is no behavior change for other RG name patterns.

## Changes

- `.github/workflows/integration-test.yml` -- renamed `SOURCE_RG` / `TARGET_RG` env vars
- `tests/integration/all-resource-types/modules/LogMasking.psm1` -- added numeric-suffix-aware regex in `Protect-ResourceGroupName`