### PR TITLE
feat: add GitHub issue templates for bugs, features, and questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -30,9 +30,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: npm package version
-      description: "Run `npm list @azure/apiops` or check your package.json to find the version."
-      placeholder: "1.0.0"
+      description: "Run `apiops --version` (or `npm list -g @peterhauge/apiops-cli`) to find the installed version."
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,59 @@
+name: Bug Report
+description: Report a bug with apiops CLI
+labels: ["bug"]
+body:
+  - type: input
+    id: command
+    attributes:
+      label: Command that triggered the bug
+      description: Which CLI command were you running?
+      placeholder: "apiops init"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: npm package version
+      description: Which version of apiops are you using?
+      placeholder: "1.0.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: "OS, Node.js version, shell, and any other relevant info."
+      placeholder: |
+        - OS: Windows 11
+        - Node.js: 20.11.0
+        - Shell: PowerShell 7.4
+    validations:
+      required: true
+
+  - type: dropdown
+    id: blocking
+    attributes:
+      label: Is this bug blocking you?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -31,7 +31,7 @@ body:
     id: version
     attributes:
       label: npm package version
-      description: Which version of apiops are you using?
+      description: "Run `npm list @azure/apiops` or check your package.json to find the version."
       placeholder: "1.0.0"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -39,10 +39,6 @@ body:
     attributes:
       label: Environment details
       description: "OS, Node.js version, shell, and any other relevant info."
-      placeholder: |
-        - OS: Windows 11
-        - Node.js: 20.11.0
-        - Shell: PowerShell 7.4
     validations:
       required: true
 
@@ -67,4 +63,4 @@ body:
         - "Yes"
         - "No"
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -49,6 +49,19 @@ body:
       required: true
 
   - type: dropdown
+    id: ci-cd
+    attributes:
+      label: CI/CD environment
+      description: If this bug occurs in a CI/CD pipeline, which platform are you using?
+      options:
+        - "N/A (running locally)"
+        - "GitHub Actions"
+        - "Azure DevOps"
+        - "Other"
+    validations:
+      required: false
+
+  - type: dropdown
     id: blocking
     attributes:
       label: Is this bug blocking you?

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,28 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["type:feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like
+    validations:
+      required: true
+
+  - type: input
+    id: affected-command
+    attributes:
+      label: Affected command
+      description: Which command does this relate to, if any?
+      placeholder: "apiops generate"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -21,8 +21,6 @@ body:
   - type: input
     id: affected-command
     attributes:
-      label: Affected command
-      description: Which command does this relate to, if any?
-      placeholder: "apiops generate"
+      placeholder: "apiops extract"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,19 @@
+name: Question
+description: Ask a usage question or request clarification
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Any additional context that might help us answer
+    validations:
+      required: false


### PR DESCRIPTION
## Why

The repo has no issue templates, which means bug reports and feature requests arrive in inconsistent formats. Adding structured YAML issue forms gives contributors clear guidance and ensures we capture the right details up front.

## What this adds

Three YAML-based issue form templates under `.github/ISSUE_TEMPLATE/`:

- **bug-report.yml** (auto-labels: `bug`) -- Captures the command, expected/actual behavior, npm package version (with instructions on how to find it), environment details, CI/CD platform, and whether the bug is blocking.
- **feature-request.yml** (auto-labels: `type:feature`) -- Captures the problem/use case, proposed solution, and optionally which command is affected.
- **question.yml** (auto-labels: `question`) -- Simple form for usage questions with optional context.

## Notes

- Uses GitHub's modern YAML issue form syntax (dropdowns, inputs, textareas with validation) rather than the older markdown template format.
- Labels are applied automatically via the `labels:` key in each template.
- All required fields have `validations.required: true` so incomplete submissions are caught early.