### PR TITLE
fix: add missing labels so issue form templates render in the UI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -30,6 +30,7 @@ body:
   - type: input
     id: version
     attributes:
+      label: apiops CLI version
       description: "Run `apiops --version` (or `npm list -g @peterhauge/apiops-cli`) to find the installed version."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -21,6 +21,8 @@ body:
   - type: input
     id: affected-command
     attributes:
+      label: Affected command
+      description: Which CLI command does this feature relate to (if any)?
       placeholder: "apiops extract"
     validations:
       required: false


### PR DESCRIPTION
## Summary

The GitHub issue form templates added in #184 were not appearing in the new-issue chooser. GitHub silently rejects any issue form containing a field without an `attributes.label`, which dropped the affected forms from the UI entirely.

This branch fixes the two invalid templates:

- **bug-report.yml** — the `version` field had only a `description`, no `label`. Added `label: apiops CLI version`.
- **feature-request.yml** — the `affected-command` field had only a `placeholder`, no `label`. Added `label: Affected command` and a description.

`question.yml` was already valid and is unchanged.

All three templates now pass issue-form validation (every input/textarea/dropdown has a label; dropdowns have options).

## Note

GitHub only renders the issue chooser from templates on the **default branch**, so the UI will update once this merges to `main`.
