### PR TITLE
docs: add prompt files documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ docs/
 │   ├── multi-team-workflows.md        — Selective extraction, CODEOWNERS
 │   ├── code-first-workflow.md         — IDE → git → CI/CD → APIM
 │   ├── token-substitution.md          — Pipeline token/placeholder substitution
+│   ├── prompt-files.md                — Copilot prompt files for APIOps tasks
 │   └── migration-from-v1.md           — Migrate from Azure/apiops toolkit
 ├── ci-cd/
 │   ├── github-actions.md              — GitHub Actions integration

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -1,0 +1,98 @@
+# Prompt Files
+
+APIOps provides [prompt files](https://code.visualstudio.com/docs/copilot/copilot-customization#_reusable-prompt-files-experimental) that guide GitHub Copilot through common APIOps configuration tasks. These are reusable `.prompt.md` files that give Copilot the context it needs to help you configure extraction filters, environment overrides, and CI/CD identity setup.
+
+## What are prompt files?
+
+Prompt files are markdown files with a `.prompt.md` extension that provide instructions and context to GitHub Copilot. When you open a prompt file in VS Code and invoke Copilot, it uses the file's content as context to guide you through a task interactively.
+
+## Available prompt files
+
+| File | Description |
+|------|-------------|
+| `apiops-configure-filter.prompt.md` | Guides Copilot through creating a `configuration.extractor.yaml` filter file to control which API Management resources are extracted. |
+| `apiops-configure-overrides.prompt.md` | Guides Copilot through creating environment override files (`configuration.<env>.yaml`) for promoting APIs across environments. |
+| `apiops-setup-workflow-identity.prompt.md` | Walks through setting up Azure identity (app registration, federated credentials, RBAC) for GitHub Actions or Azure DevOps CI/CD pipelines. |
+
+## Getting prompt files
+
+### Via `apiops init` (recommended)
+
+The easiest way to get prompt files is to run [`apiops init`](../commands/init.md), which scaffolds your repository with prompt files already in place at `.github/prompts/`.
+
+### Download individually
+
+If you already have an APIOps repository and want to add prompt files without re-running init, you can download them directly from this repository.
+
+#### Bash
+
+```bash
+# Create the prompts directory
+mkdir -p .github/prompts
+
+# Download prompt files
+curl -sL "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/configure-filter-prompt.md" \
+  -o ".github/prompts/apiops-configure-filter.prompt.md"
+
+curl -sL "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/configure-overrides-prompt.md" \
+  -o ".github/prompts/apiops-configure-overrides.prompt.md"
+
+# For GitHub Actions identity setup:
+curl -sL "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/identity-setup-prompt-github-actions.md" \
+  -o ".github/prompts/apiops-setup-workflow-identity.prompt.md"
+
+# For Azure DevOps identity setup:
+curl -sL "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/identity-setup-prompt-azure-devops.md" \
+  -o ".github/prompts/apiops-setup-workflow-identity.prompt.md"
+```
+
+#### PowerShell
+
+```powershell
+# Create the prompts directory
+New-Item -ItemType Directory -Path ".github/prompts" -Force
+
+# Download prompt files
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/configure-filter-prompt.md" `
+  -OutFile ".github/prompts/apiops-configure-filter.prompt.md"
+
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/configure-overrides-prompt.md" `
+  -OutFile ".github/prompts/apiops-configure-overrides.prompt.md"
+
+# For GitHub Actions identity setup:
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/identity-setup-prompt-github-actions.md" `
+  -OutFile ".github/prompts/apiops-setup-workflow-identity.prompt.md"
+
+# For Azure DevOps identity setup:
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/identity-setup-prompt-azure-devops.md" `
+  -OutFile ".github/prompts/apiops-setup-workflow-identity.prompt.md"
+```
+
+## Using prompt files
+
+### In VS Code
+
+1. Open the prompt file (e.g., `.github/prompts/apiops-configure-filter.prompt.md`) in VS Code.
+2. Open the Copilot Chat panel and type `#` followed by the prompt file name, or use the **Attach Context** button to select it.
+3. Ask Copilot to help you complete the task described in the prompt.
+
+For more details on using prompt files in VS Code, see the [VS Code documentation on reusable prompt files](https://code.visualstudio.com/docs/copilot/copilot-customization#_reusable-prompt-files-experimental).
+
+### In GitHub Copilot CLI
+
+You can reference prompt files when using [GitHub Copilot in the CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli):
+
+```bash
+# Ask Copilot CLI to use a prompt file as context
+gh copilot suggest --file .github/prompts/apiops-configure-filter.prompt.md "help me configure extraction filters"
+```
+
+For more details, see the [GitHub Copilot in the CLI documentation](https://docs.github.com/en/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli).
+
+## Further reading
+
+- [VS Code: Reusable prompt files](https://code.visualstudio.com/docs/copilot/copilot-customization#_reusable-prompt-files-experimental)
+- [GitHub Copilot in the CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli)
+- [APIOps `init` command reference](../commands/init.md)
+- [Filtering resources guide](./filtering-resources.md)
+- [Environment overrides guide](./environment-overrides.md)

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -81,4 +81,3 @@ foreach ($file in $files) {
 
 - [VS Code: Reusable prompt files](https://code.visualstudio.com/docs/copilot/copilot-customization#_reusable-prompt-files-experimental)
 - [GitHub Copilot in the CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli)
-- [APIOps `init` command reference](../commands/init.md)

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -10,8 +10,8 @@ Prompt files are markdown files with a `.prompt.md` extension that provide instr
 
 | File | Description |
 |------|-------------|
-| `apiops-configure-filter.prompt.md` | Guides Copilot through creating a `configuration.extractor.yaml` filter file to control which API Management resources are extracted. |
-| `apiops-configure-overrides.prompt.md` | Guides Copilot through creating environment override files (`configuration.<env>.yaml`) for promoting APIs across environments. |
+| `apiops-configure-filter.prompt.md` | Guides Copilot through creating a `configuration.extractor.yaml` filter file to control which API Management resources are extracted. See also: [Filtering resources guide](./filtering-resources.md) |
+| `apiops-configure-overrides.prompt.md` | Guides Copilot through creating environment override files (`configuration.<env>.yaml`) for promoting APIs across environments. See also: [Environment overrides guide](./environment-overrides.md) |
 | `apiops-setup-workflow-identity.prompt.md` | Walks through setting up Azure identity (app registration, federated credentials, RBAC) for your CI/CD pipeline. There are separate versions for GitHub Actions and Azure DevOps — `apiops init` selects the correct one based on your chosen CI provider. |
 
 ## Getting prompt files
@@ -75,5 +75,3 @@ foreach ($file in $files) {
 - [VS Code: Reusable prompt files](https://code.visualstudio.com/docs/copilot/copilot-customization#_reusable-prompt-files-experimental)
 - [GitHub Copilot in the CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli)
 - [APIOps `init` command reference](../commands/init.md)
-- [Filtering resources guide](./filtering-resources.md)
-- [Environment overrides guide](./environment-overrides.md)

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -12,7 +12,7 @@ Prompt files are markdown files with a `.prompt.md` extension that provide instr
 |------|-------------|
 | `apiops-configure-filter.prompt.md` | Guides Copilot through creating a `configuration.extractor.yaml` filter file to control which API Management resources are extracted. |
 | `apiops-configure-overrides.prompt.md` | Guides Copilot through creating environment override files (`configuration.<env>.yaml`) for promoting APIs across environments. |
-| `apiops-setup-workflow-identity.prompt.md` | Walks through setting up Azure identity (app registration, federated credentials, RBAC) for GitHub Actions or Azure DevOps CI/CD pipelines. |
+| `apiops-setup-workflow-identity.prompt.md` | Walks through setting up Azure identity (app registration, federated credentials, RBAC) for your CI/CD pipeline. There are separate versions for GitHub Actions and Azure DevOps — `apiops init` selects the correct one based on your chosen CI provider. |
 
 ## Getting prompt files
 

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -70,27 +70,6 @@ foreach ($file in $files) {
 }
 ```
 
-## Using prompt files
-
-### In VS Code
-
-1. Open the prompt file (e.g., `.github/prompts/apiops-configure-filter.prompt.md`) in VS Code.
-2. Open the Copilot Chat panel and type `#` followed by the prompt file name, or use the **Attach Context** button to select it.
-3. Ask Copilot to help you complete the task described in the prompt.
-
-For more details on using prompt files in VS Code, see the [VS Code documentation on reusable prompt files](https://code.visualstudio.com/docs/copilot/copilot-customization#_reusable-prompt-files-experimental).
-
-### In GitHub Copilot CLI
-
-You can reference prompt files when using [GitHub Copilot in the CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli):
-
-```bash
-# Ask Copilot CLI to use a prompt file as context
-gh copilot suggest --file .github/prompts/apiops-configure-filter.prompt.md "help me configure extraction filters"
-```
-
-For more details, see the [GitHub Copilot in the CLI documentation](https://docs.github.com/en/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli).
-
 ## Further reading
 
 - [VS Code: Reusable prompt files](https://code.visualstudio.com/docs/copilot/copilot-customization#_reusable-prompt-files-experimental)

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -34,7 +34,7 @@ mkdir -p .github/prompts
 files=(
   "configure-filter-prompt.md:apiops-configure-filter.prompt.md"
   "configure-overrides-prompt.md:apiops-configure-overrides.prompt.md"
-  # Choose ONE of the following identity setup prompts:
+  # Remove the identity setup prompt that doesn't apply to your CI provider:
   "identity-setup-prompt-github-actions.md:apiops-setup-workflow-identity.prompt.md"
   # "identity-setup-prompt-azure-devops.md:apiops-setup-workflow-identity.prompt.md"
 )
@@ -59,7 +59,7 @@ New-Item -ItemType Directory -Path ".github/prompts" -Force | Out-Null
 $files = @(
   @{ Source = "configure-filter-prompt.md"; Dest = "apiops-configure-filter.prompt.md" }
   @{ Source = "configure-overrides-prompt.md"; Dest = "apiops-configure-overrides.prompt.md" }
-  # Choose ONE of the following identity setup prompts:
+  # Remove the identity setup prompt that doesn't apply to your CI provider:
   @{ Source = "identity-setup-prompt-github-actions.md"; Dest = "apiops-setup-workflow-identity.prompt.md" }
   # @{ Source = "identity-setup-prompt-azure-devops.md"; Dest = "apiops-setup-workflow-identity.prompt.md" }
 )

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -28,8 +28,11 @@ If you already have an APIOps repository and want to add prompt files without re
 #### Bash
 
 ```bash
+# Resolve repo root so this works from any subdirectory
+repo_root="$(git rev-parse --show-toplevel)"
+
 # Create the prompts directory
-mkdir -p .github/prompts
+mkdir -p "${repo_root}/.github/prompts"
 
 # Available prompt files — remove any you don't need
 files=(
@@ -43,7 +46,7 @@ files=(
 base_url="https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot"
 
 for file in "${files[@]}"; do
-  curl -sL "${base_url}/${file}" -o ".github/prompts/${file}"
+  curl -sL "${base_url}/${file}" -o "${repo_root}/.github/prompts/${file}"
   echo "Downloaded ${file}"
 done
 ```
@@ -51,8 +54,11 @@ done
 #### PowerShell
 
 ```powershell
+# Resolve repo root so this works from any subdirectory
+$repoRoot = git rev-parse --show-toplevel
+
 # Create the prompts directory
-New-Item -ItemType Directory -Path ".github/prompts" -Force | Out-Null
+New-Item -ItemType Directory -Path "$repoRoot/.github/prompts" -Force | Out-Null
 
 # Available prompt files — remove any you don't need
 $files = @(
@@ -66,7 +72,7 @@ $files = @(
 $baseUrl = "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot"
 
 foreach ($file in $files) {
-  Invoke-WebRequest -Uri "$baseUrl/$file" -OutFile ".github/prompts/$file"
+  Invoke-WebRequest -Uri "$baseUrl/$file" -OutFile "$repoRoot/.github/prompts/$file"
   Write-Host "Downloaded $file"
 }
 ```

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -30,42 +30,46 @@ If you already have an APIOps repository and want to add prompt files without re
 # Create the prompts directory
 mkdir -p .github/prompts
 
-# Download prompt files
-curl -sL "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/configure-filter-prompt.md" \
-  -o ".github/prompts/apiops-configure-filter.prompt.md"
+# Available prompt files — comment out any you don't need
+files=(
+  "configure-filter-prompt.md:apiops-configure-filter.prompt.md"
+  "configure-overrides-prompt.md:apiops-configure-overrides.prompt.md"
+  # Choose ONE of the following identity setup prompts:
+  "identity-setup-prompt-github-actions.md:apiops-setup-workflow-identity.prompt.md"
+  # "identity-setup-prompt-azure-devops.md:apiops-setup-workflow-identity.prompt.md"
+)
 
-curl -sL "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/configure-overrides-prompt.md" \
-  -o ".github/prompts/apiops-configure-overrides.prompt.md"
+base_url="https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot"
 
-# For GitHub Actions identity setup:
-curl -sL "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/identity-setup-prompt-github-actions.md" \
-  -o ".github/prompts/apiops-setup-workflow-identity.prompt.md"
-
-# For Azure DevOps identity setup:
-curl -sL "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/identity-setup-prompt-azure-devops.md" \
-  -o ".github/prompts/apiops-setup-workflow-identity.prompt.md"
+for entry in "${files[@]}"; do
+  src="${entry%%:*}"
+  dest="${entry##*:}"
+  curl -sL "${base_url}/${src}" -o ".github/prompts/${dest}"
+  echo "Downloaded ${dest}"
+done
 ```
 
 #### PowerShell
 
 ```powershell
 # Create the prompts directory
-New-Item -ItemType Directory -Path ".github/prompts" -Force
+New-Item -ItemType Directory -Path ".github/prompts" -Force | Out-Null
 
-# Download prompt files
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/configure-filter-prompt.md" `
-  -OutFile ".github/prompts/apiops-configure-filter.prompt.md"
+# Available prompt files — comment out any you don't need
+$files = @(
+  @{ Source = "configure-filter-prompt.md"; Dest = "apiops-configure-filter.prompt.md" }
+  @{ Source = "configure-overrides-prompt.md"; Dest = "apiops-configure-overrides.prompt.md" }
+  # Choose ONE of the following identity setup prompts:
+  @{ Source = "identity-setup-prompt-github-actions.md"; Dest = "apiops-setup-workflow-identity.prompt.md" }
+  # @{ Source = "identity-setup-prompt-azure-devops.md"; Dest = "apiops-setup-workflow-identity.prompt.md" }
+)
 
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/configure-overrides-prompt.md" `
-  -OutFile ".github/prompts/apiops-configure-overrides.prompt.md"
+$baseUrl = "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot"
 
-# For GitHub Actions identity setup:
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/identity-setup-prompt-github-actions.md" `
-  -OutFile ".github/prompts/apiops-setup-workflow-identity.prompt.md"
-
-# For Azure DevOps identity setup:
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot/identity-setup-prompt-azure-devops.md" `
-  -OutFile ".github/prompts/apiops-setup-workflow-identity.prompt.md"
+foreach ($file in $files) {
+  Invoke-WebRequest -Uri "$baseUrl/$($file.Source)" -OutFile ".github/prompts/$($file.Dest)"
+  Write-Host "Downloaded $($file.Dest)"
+}
 ```
 
 ## Using prompt files

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -32,20 +32,18 @@ mkdir -p .github/prompts
 
 # Available prompt files — remove any you don't need
 files=(
-  "configure-filter-prompt.md:apiops-configure-filter.prompt.md"
-  "configure-overrides-prompt.md:apiops-configure-overrides.prompt.md"
+  "apiops-configure-filter.prompt.md"
+  "apiops-configure-overrides.prompt.md"
   # Remove the identity setup prompt that doesn't apply to your CI provider:
-  "identity-setup-prompt-github-actions.md:apiops-setup-workflow-identity.prompt.md"
-  "identity-setup-prompt-azure-devops.md:apiops-setup-workflow-identity.prompt.md"
+  "apiops-setup-workflow-identity-github-actions.prompt.md"
+  "apiops-setup-workflow-identity-azure-devops.prompt.md"
 )
 
 base_url="https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot"
 
-for entry in "${files[@]}"; do
-  src="${entry%%:*}"
-  dest="${entry##*:}"
-  curl -sL "${base_url}/${src}" -o ".github/prompts/${dest}"
-  echo "Downloaded ${dest}"
+for file in "${files[@]}"; do
+  curl -sL "${base_url}/${file}" -o ".github/prompts/${file}"
+  echo "Downloaded ${file}"
 done
 ```
 
@@ -57,18 +55,18 @@ New-Item -ItemType Directory -Path ".github/prompts" -Force | Out-Null
 
 # Available prompt files — remove any you don't need
 $files = @(
-  @{ Source = "configure-filter-prompt.md"; Dest = "apiops-configure-filter.prompt.md" }
-  @{ Source = "configure-overrides-prompt.md"; Dest = "apiops-configure-overrides.prompt.md" }
+  "apiops-configure-filter.prompt.md"
+  "apiops-configure-overrides.prompt.md"
   # Remove the identity setup prompt that doesn't apply to your CI provider:
-  @{ Source = "identity-setup-prompt-github-actions.md"; Dest = "apiops-setup-workflow-identity.prompt.md" }
-  @{ Source = "identity-setup-prompt-azure-devops.md"; Dest = "apiops-setup-workflow-identity.prompt.md" }
+  "apiops-setup-workflow-identity-github-actions.prompt.md"
+  "apiops-setup-workflow-identity-azure-devops.prompt.md"
 )
 
 $baseUrl = "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot"
 
 foreach ($file in $files) {
-  Invoke-WebRequest -Uri "$baseUrl/$($file.Source)" -OutFile ".github/prompts/$($file.Dest)"
-  Write-Host "Downloaded $($file.Dest)"
+  Invoke-WebRequest -Uri "$baseUrl/$file" -OutFile ".github/prompts/$file"
+  Write-Host "Downloaded $file"
 }
 ```
 

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -30,13 +30,13 @@ If you already have an APIOps repository and want to add prompt files without re
 # Create the prompts directory
 mkdir -p .github/prompts
 
-# Available prompt files — comment out any you don't need
+# Available prompt files — remove any you don't need
 files=(
   "configure-filter-prompt.md:apiops-configure-filter.prompt.md"
   "configure-overrides-prompt.md:apiops-configure-overrides.prompt.md"
   # Remove the identity setup prompt that doesn't apply to your CI provider:
   "identity-setup-prompt-github-actions.md:apiops-setup-workflow-identity.prompt.md"
-  # "identity-setup-prompt-azure-devops.md:apiops-setup-workflow-identity.prompt.md"
+  "identity-setup-prompt-azure-devops.md:apiops-setup-workflow-identity.prompt.md"
 )
 
 base_url="https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot"
@@ -55,13 +55,13 @@ done
 # Create the prompts directory
 New-Item -ItemType Directory -Path ".github/prompts" -Force | Out-Null
 
-# Available prompt files — comment out any you don't need
+# Available prompt files — remove any you don't need
 $files = @(
   @{ Source = "configure-filter-prompt.md"; Dest = "apiops-configure-filter.prompt.md" }
   @{ Source = "configure-overrides-prompt.md"; Dest = "apiops-configure-overrides.prompt.md" }
   # Remove the identity setup prompt that doesn't apply to your CI provider:
   @{ Source = "identity-setup-prompt-github-actions.md"; Dest = "apiops-setup-workflow-identity.prompt.md" }
-  # @{ Source = "identity-setup-prompt-azure-devops.md"; Dest = "apiops-setup-workflow-identity.prompt.md" }
+  @{ Source = "identity-setup-prompt-azure-devops.md"; Dest = "apiops-setup-workflow-identity.prompt.md" }
 )
 
 $baseUrl = "https://raw.githubusercontent.com/Azure/apiops-cli/main/src/templates/copilot"

--- a/docs/guides/prompt-files.md
+++ b/docs/guides/prompt-files.md
@@ -12,7 +12,8 @@ Prompt files are markdown files with a `.prompt.md` extension that provide instr
 |------|-------------|
 | `apiops-configure-filter.prompt.md` | Guides Copilot through creating a `configuration.extractor.yaml` filter file to control which API Management resources are extracted. See also: [Filtering resources guide](./filtering-resources.md) |
 | `apiops-configure-overrides.prompt.md` | Guides Copilot through creating environment override files (`configuration.<env>.yaml`) for promoting APIs across environments. See also: [Environment overrides guide](./environment-overrides.md) |
-| `apiops-setup-workflow-identity.prompt.md` | Walks through setting up Azure identity (app registration, federated credentials, RBAC) for your CI/CD pipeline. There are separate versions for GitHub Actions and Azure DevOps — `apiops init` selects the correct one based on your chosen CI provider. |
+| `apiops-setup-workflow-identity-github-actions.prompt.md` | Walks through setting up Azure identity (app registration, federated credentials, RBAC) for GitHub Actions CI/CD pipelines. |
+| `apiops-setup-workflow-identity-azure-devops.prompt.md` | Walks through setting up Azure identity (app registration, federated credentials, RBAC) for Azure DevOps CI/CD pipelines. |
 
 ## Getting prompt files
 


### PR DESCRIPTION
## Summary

Adds a new documentation article at `docs/guides/prompt-files.md` that describes the prompt files available in the repository and how to use them independently of `apiops init`.

## What's included

- Table listing all available prompt files and their purpose
- Download instructions for **Bash** and **PowerShell** to fetch prompt files directly from the repo
- Usage guidance for **VS Code** (with links to official docs on reusable prompt files)
- Usage guidance for **GitHub Copilot CLI** (with links to official docs)
- Links to related guides (filtering, environment overrides, init command)

## Related Issue(s)

N/A — documentation enhancement

## Base branch

This PR targets `emaher-rename-and-rewrite-init-files` since it depends on the prompt markdown files introduced in that branch.