### PR TITLE
fix: drop stale mcpServerInformation.json references

### DIFF
--- a/docs/reference/artifact-format.md
+++ b/docs/reference/artifact-format.md
@@ -27,7 +27,6 @@ apim-artifacts/
 │       ├── policy.xml                      # API-level policy
 │       ├── specification.yaml              # OpenAPI spec (if applicable)
 │       ├── wiki.md                         # API wiki (if exists)
-│       ├── mcpServerInformation.json       # MCP server config (if exists)
 │       ├── operations/
 │       │   └── get-pets/
 │       │       └── policy.xml              # Operation-level policy
@@ -151,7 +150,7 @@ All 34 APIM resource types and their artifact mappings:
 | ApiWiki | `apis/{api}` | `wiki.md` |
 | GraphQLResolver | `apis/{api}/resolvers/{resolver}` | `resolverInformation.json` |
 | GraphQLResolverPolicy | `apis/{api}/resolvers/{resolver}` | `policy.xml` |
-| McpServer | `apis/{api}` | `mcpServerInformation.json` |
+| McpServer | `apis/{api}` | _embedded in `apiInformation.json`_ |
 
 ### Gateway Child Resources
 

--- a/docs/reference/resource-types.md
+++ b/docs/reference/resource-types.md
@@ -67,7 +67,7 @@ Resources scoped to a specific API.
 | ApiWiki | `/apis/{name}/wikis/default` | `apis/{0}` | `wiki.md` | Markdown documentation page for an API |
 | GraphQLResolver | `/apis/{name}/resolvers/{resolver}` | `apis/{0}/resolvers/{1}` | `resolverInformation.json` | GraphQL field resolver configuration |
 | GraphQLResolverPolicy | `/apis/{name}/resolvers/{resolver}/policies/policy` | `apis/{0}/resolvers/{1}` | `policy.xml` | Policy applied to a GraphQL resolver |
-| McpServer | `/apis/{name}/mcpServers/default` | `apis/{0}` | `mcpServerInformation.json` | MCP (Model Context Protocol) server linked to an API |
+| McpServer | `/apis/{name}/mcpServers/default` | `apis/{0}` | _embedded in `apiInformation.json`_ | MCP (Model Context Protocol) server linked to an API |
 
 ## Gateway Resources
 

--- a/tests/integration/all-resource-types/expected-structure.json
+++ b/tests/integration/all-resource-types/expected-structure.json
@@ -614,15 +614,13 @@
         },
         {
           "name": "src-mcp-todos",
-          "files": ["apiInformation.json", "mcpServerInformation.json", "policy.xml"],
+          "files": ["apiInformation.json", "policy.xml"],
           "spotChecks": {
             "apiInformation.json": {
               "properties.displayName": "KS MCP Todos Server",
               "properties.path": "ks/mcp-todos",
               "properties.type": "mcp",
-              "properties.subscriptionRequired": false
-            },
-            "mcpServerInformation.json": {
+              "properties.subscriptionRequired": false,
               "properties.mcpProperties.endpoints.mcp.uriTemplate": "/mcp",
               "properties.mcpTools": "exists"
             }


### PR DESCRIPTION
## Summary

PR #173 moved MCP (Model Context Protocol) server configuration into `apiInformation.json` and stopped producing/consuming the redundant `mcpServerInformation.json` sidecar. Several references to that removed sidecar were left behind, causing the `all-resource-types` round-trip integration test to fail (**2 of 349 checks**) on the `src-mcp-todos` MCP API — it still expected a `mcpServerInformation.json` file that is no longer emitted.

This PR removes the stale references so the manifest and docs reflect the post-#173 behavior.

## Changes

- **`tests/integration/all-resource-types/expected-structure.json`** — for `src-mcp-todos`, remove `mcpServerInformation.json` from the expected `files` list and delete its spot-check block; fold the two checks (`properties.mcpProperties.endpoints.mcp.uriTemplate` and `properties.mcpTools`) into the `apiInformation.json` spot-check where the data now lives.
- **`docs/reference/artifact-format.md`** — drop the `mcpServerInformation.json` line from the directory tree, annotate `apiInformation.json` as carrying MCP server config, and update the McpServer table row to _embedded in `apiInformation.json`_.
- **`docs/reference/resource-types.md`** — update the McpServer row's info-file column to _embedded in `apiInformation.json`_.

## Validation

Re-ran the artifact validation phase (`Test-ExtractedArtifact.ps1`) against the extracted artifacts from a Premium round-trip run:

```
Summary: 349/349 checks passed, 0 failures
```

## Related

- Follow-up to #173 (MCP publish from embedded API metadata)

## Notes

This is a test-manifest/docs staleness fix only — no `src/` behavior changes.