### PR TITLE
docs: fix filter documentation drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ Extract APIM service configuration to local artifact files.
 | `--resource-group <rg>` | *(required)* | Azure resource group |
 | `--service-name <name>` | *(required)* | APIM service name |
 | `--output <dir>` | `./apim-artifacts` | Output directory |
-| `--filter <path>` | | Extract only matching resources |
+| `--filter <path>` | | Extract matching resources; supports wildcards and `!` exclusions |
 | `--no-transitive` | | Skip transitive dependencies |
+
+Filter files support exact names, wildcards, quoted `!`-prefixed exclusions, and the singleton `policies` key. See the [extract command filter reference](docs/commands/extract.md#filter-configuration) for all 17 filter keys and the [filtering guide](docs/guides/filtering-resources.md) for detailed examples.
 
 ```bash
 apiops extract --help

--- a/docs/guides/filtering-resources.md
+++ b/docs/guides/filtering-resources.md
@@ -200,16 +200,14 @@ namedValues:
   - '!keyvault-*'
 ```
 
-Exclusions work anywhere a string list is accepted, including sub-filter fields inside `apiSubFilters` and `workspaceSubFilters`:
+Exclusions work anywhere a string list is accepted, including nested API and workspace sub-filter entries:
 
 ```yaml
 apis:
-  - 'my-api'
-apiSubFilters:
-  my-api:
-    operations:
-      - 'get-*'
-      - '!get-internal-*'   # keep all get-* operations except internal ones
+  - 'my-api':
+      operations:
+        - 'get-*'
+        - '!get-internal-*'   # keep all get-* operations except internal ones
 ```
 
 ---
@@ -260,7 +258,7 @@ Supported workspace sub-filter keys: `apis`, `backends`, `diagnostics`, `groups`
 
 ---
 
-## All 16 Filterable Resource Types
+## All 17 Filterable Resource Types
 
 | Filter Field | APIM Resource | Example Values |
 |-------------|---------------|----------------|
@@ -401,7 +399,7 @@ backends:
 
 ### Full Extract Minus Specific Resources
 
-There is no "exclude" syntax. To extract everything except certain resources, list all the resources you _do_ want. For large instances, it's often easier to extract everything and use `.gitignore` or separate branches to manage visibility.
+Use quoted `!`-prefixed entries to exclude specific resources. A list containing only exclusions includes every resource that does not match them; combine `'*'` with exclusions when you want to make the include-all intent explicit. See [Excluding resources with `!`](#excluding-resources-with-) for examples and matching rules.
 
 ### Pattern-Based Team Filtering
 


### PR DESCRIPTION
## Summary

- document wildcard and exclusion filtering, the singleton policies key, and detailed filter references in the README
- replace the internal apiSubFilters YAML example with the supported nested API syntax
- correct the filterable resource count and stale exclusion guidance

## Validation

- npm run lint
- npm test (1,111 tests passed)
- focused documentation drift assertions

## Related Issue(s)

Closes #228
Closes #229
