### PR TITLE
chore: use GPT-5.6 Sol for Squad

### DIFF
--- a/.squad/config.json
+++ b/.squad/config.json
@@ -1,8 +1,4 @@
 {
   "version": 1,
-  "defaultModel": "claude-opus-4.6",
-  "agentModelOverrides": {
-    "ralph": "claude-haiku-4.5",
-    "scribe": "claude-haiku-4.5"
-  }
+  "defaultModel": "gpt-5.6-sol"
 }


### PR DESCRIPTION
This PR updates the default model for Squad from Claude Opus 4.6 to regular GPT-5.6 Sol. It also removes the Ralph and Scribe Claude overrides, so all agents inherit the default model. Validation: .squad/config.json is successfully verified as valid JSON.