### PR TITLE
fix: repair extract→publish round trip for SOAP APIs, gateway associations, and concurrent deletes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,16 +1694,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2328,9 +2328,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -2771,9 +2771,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2903,9 +2903,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2923,7 +2923,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/src/clients/apim-client.ts
+++ b/src/clients/apim-client.ts
@@ -57,6 +57,10 @@ export class ApimClient implements IApimClient {
   private static readonly ASYNC_POLL_TIMEOUT_MS = 7.5 * 60 * 1000;
   /** Default interval between async operation polls when no Retry-After header. */
   private static readonly ASYNC_POLL_INTERVAL_MS = 5000;
+  /** Max DELETE attempts when APIM reports an optimistic-concurrency conflict. */
+  private static readonly DELETE_CONFLICT_RETRIES = 3;
+  /** Base delay between DELETE conflict retries (multiplied by attempt number). */
+  private static readonly DELETE_CONFLICT_RETRY_DELAY_MS = 2000;
   /** Known ARM management plane host suffixes for URL validation. */
   private static readonly ARM_HOSTS = [
     'management.azure.com',
@@ -451,32 +455,49 @@ export class ApimClient implements IApimClient {
     descriptor: ResourceDescriptor
   ): Promise<boolean> {
     const url = buildArmUri(context, descriptor);
-    
-    try {
-      const response = await this.request(url, { method: 'DELETE' });
-      
-      if (response.status === 404) {
-        return false; // Already deleted
-      }
 
-      // Poll for long-running operations
-      if (response.status === 202) {
-        const asyncUrl = this.extractAsyncOperationUrl(response);
-        if (asyncUrl) {
-          await this.pollAsyncOperation(asyncUrl, context, descriptor, { treatMissingAsSuccess: true });
-        } else {
-          await this.pollProvisioningState(context, descriptor, {
-            treatMissingAsSuccess: true,
-          });
+    for (let attempt = 1; ; attempt++) {
+      try {
+        const response = await this.request(url, { method: 'DELETE' });
+
+        if (response.status === 404) {
+          return false; // Already deleted
         }
-      }
 
-      return true;
-    } catch (error) {
-      if ((error as Error).message.includes('404')) {
-        return false;
+        // Poll for long-running operations
+        if (response.status === 202) {
+          const asyncUrl = this.extractAsyncOperationUrl(response);
+          if (asyncUrl) {
+            await this.pollAsyncOperation(asyncUrl, context, descriptor, { treatMissingAsSuccess: true });
+          } else {
+            await this.pollProvisioningState(context, descriptor, {
+              treatMissingAsSuccess: true,
+            });
+          }
+        }
+
+        return true;
+      } catch (error) {
+        const message = (error as Error).message;
+        if (message.includes('404')) {
+          return false;
+        }
+        // Transient optimistic-concurrency conflict: cascade deletes of related
+        // resources (subscriptions, product/gateway associations) can modify
+        // the resource while its async DELETE is in flight. Retry the DELETE.
+        const isConflict =
+          message.includes('[PreconditionFailed]') ||
+          (error instanceof HttpError && error.status === 412);
+        if (isConflict && attempt < ApimClient.DELETE_CONFLICT_RETRIES) {
+          logger.warn(
+            `Delete conflict for ${buildResourceLabel(descriptor)} ` +
+            `(attempt ${attempt}/${ApimClient.DELETE_CONFLICT_RETRIES}), retrying...`
+          );
+          await this.delay(ApimClient.DELETE_CONFLICT_RETRY_DELAY_MS * attempt);
+          continue;
+        }
+        throw error;
       }
-      throw error;
     }
   }
 

--- a/src/lib/wsdl-normalizer.ts
+++ b/src/lib/wsdl-normalizer.ts
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+/**
+ * WSDL normalizer
+ *
+ * APIM's WSDL export regenerates the document from its internal API model and
+ * has a known defect: `wsdl:part element="..."` references are qualified with
+ * the WSDL targetNamespace prefix (`tns`) even when the element is declared in
+ * a different inline schema namespace. APIM's own importer then rejects the
+ * document with "Could not resolve type '{ns}Element'", breaking the
+ * extract → publish round trip for multi-namespace WSDLs.
+ *
+ * This module rewrites such unresolvable part references to the prefix of the
+ * inline schema that actually declares the element. Only references that are
+ * (a) unresolvable as-is and (b) declared in exactly one inline schema are
+ * rewritten; everything else is left untouched.
+ */
+
+import { logger } from './logger.js';
+
+const NAME = String.raw`[\w.-]+`;
+
+/**
+ * Apply all WSDL export-defect normalizations needed for the extract →
+ * publish round trip.
+ */
+export function normalizeWsdl(wsdl: string): string {
+  return normalizeWsdlServicePorts(normalizeWsdlPartReferences(wsdl));
+}
+
+/**
+ * Normalize `wsdl:part` element references so they resolve against the inline
+ * schemas of the document. Returns the input unchanged when no fix is needed.
+ */
+export function normalizeWsdlPartReferences(wsdl: string): string {
+  const rootMatch = new RegExp(`<(?:${NAME}:)?definitions\\b[^>]*>`).exec(wsdl);
+  if (!rootMatch) {
+    return wsdl;
+  }
+
+  const prefixToNs = parseXmlnsDeclarations(rootMatch[0]);
+  const globalElements = collectGlobalSchemaElements(wsdl);
+  if (globalElements.size === 0) {
+    return wsdl;
+  }
+
+  // First declared prefix wins for each namespace
+  const nsToPrefix = new Map<string, string>();
+  for (const [prefix, ns] of prefixToNs) {
+    if (!nsToPrefix.has(ns)) {
+      nsToPrefix.set(ns, prefix);
+    }
+  }
+
+  const newDeclarations: string[] = [];
+  let generatedPrefixCounter = 0;
+
+  const partRef = new RegExp(
+    `(<(?:${NAME}:)?part\\b[^>]*?\\belement=")(?:(${NAME}):)?(${NAME})(")`,
+    'g'
+  );
+
+  const rewritten = wsdl.replace(
+    partRef,
+    (full, before: string, prefix: string | undefined, localName: string, after: string) => {
+      // Only fix prefixed references resolvable at the root — anything else
+      // (local xmlns declarations, unprefixed refs) is left untouched.
+      if (!prefix) {
+        return full;
+      }
+      const referencedNs = prefixToNs.get(prefix);
+      if (!referencedNs) {
+        return full;
+      }
+
+      const declaredIn = globalElements.get(localName);
+      // Skip unknown or ambiguous elements (declared in several schemas)
+      if (!declaredIn || declaredIn.size !== 1) {
+        return full;
+      }
+      const actualNs = [...declaredIn][0];
+      if (actualNs === undefined || referencedNs === actualNs) {
+        return full; // already resolvable
+      }
+
+      let fixedPrefix = nsToPrefix.get(actualNs);
+      if (!fixedPrefix) {
+        fixedPrefix = `apiopsns${generatedPrefixCounter++}`;
+        nsToPrefix.set(actualNs, fixedPrefix);
+        newDeclarations.push(`xmlns:${fixedPrefix}="${actualNs}"`);
+      }
+
+      logger.debug(
+        `WSDL normalizer: rewriting wsdl:part reference ${prefix}:${localName} → ` +
+        `${fixedPrefix}:${localName} (element is declared in "${actualNs}")`
+      );
+      return `${before}${fixedPrefix}:${localName}${after}`;
+    }
+  );
+
+  if (rewritten === wsdl) {
+    return wsdl;
+  }
+
+  if (newDeclarations.length > 0) {
+    const rootTag = rootMatch[0];
+    const patchedRoot = `${rootTag.slice(0, -1)} ${newDeclarations.join(' ')}>`;
+    return rewritten.replace(rootTag, patchedRoot);
+  }
+
+  return rewritten;
+}
+
+/**
+ * APIM's WSDL export emits one `wsdl:port` per configured proxy hostname, but
+ * its importer only accepts a single service endpoint ("Multiple service
+ * endpoints available, only one can be imported at a time"). Keep the first
+ * port of each `wsdl:service` and drop the rest.
+ */
+export function normalizeWsdlServicePorts(wsdl: string): string {
+  const serviceRe = new RegExp(
+    `<(${NAME}:)?service\\b[^>]*>[\\s\\S]*?</\\1?service>`,
+    'g'
+  );
+
+  return wsdl.replace(serviceRe, (serviceBlock) => {
+    const portRe = new RegExp(
+      `\\s*<(${NAME}:)?port\\b[^>]*(?:/>|>[\\s\\S]*?</\\1?port>)`,
+      'g'
+    );
+    const ports = serviceBlock.match(portRe);
+    if (!ports || ports.length <= 1) {
+      return serviceBlock;
+    }
+
+    logger.debug(
+      `WSDL normalizer: keeping first of ${ports.length} wsdl:port endpoints`
+    );
+    let first = true;
+    return serviceBlock.replace(portRe, (port) => {
+      if (first) {
+        first = false;
+        return port;
+      }
+      return '';
+    });
+  });
+}
+
+/** Parse `xmlns:prefix="ns"` declarations from a single tag string. */
+function parseXmlnsDeclarations(tag: string): Map<string, string> {  const map = new Map<string, string>();
+  for (const m of tag.matchAll(new RegExp(`xmlns:(${NAME})="([^"]*)"`, 'g'))) {
+    map.set(m[1], m[2]);
+  }
+  return map;
+}
+
+/**
+ * Collect global (top-level) `xs:element` declarations from every inline
+ * schema, keyed by element name → set of schema targetNamespaces.
+ * Uses a depth-tracking tag scanner so nested local elements are ignored.
+ */
+function collectGlobalSchemaElements(wsdl: string): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  const tagRe = /<!--[\s\S]*?-->|<[^>]+>/g;
+
+  let schemaNs: string | undefined;
+  let depth = 0; // open-ancestor count relative to the current schema
+
+  for (const m of wsdl.matchAll(tagRe)) {
+    const raw = m[0];
+    if (raw.startsWith('<!--') || raw.startsWith('<?') || raw.startsWith('<![')) {
+      continue;
+    }
+
+    const isClose = raw.startsWith('</');
+    const isSelfClosing = raw.endsWith('/>');
+    const nameMatch = new RegExp(`^</?(?:${NAME}:)?(${NAME})`).exec(raw);
+    if (!nameMatch) {
+      continue;
+    }
+    const localName = nameMatch[1];
+
+    if (schemaNs === undefined) {
+      if (!isClose && !isSelfClosing && localName === 'schema') {
+        schemaNs = /targetNamespace="([^"]*)"/.exec(raw)?.[1];
+        depth = 1;
+      }
+      continue;
+    }
+
+    if (isClose) {
+      depth--;
+      if (depth === 0) {
+        schemaNs = undefined;
+      }
+      continue;
+    }
+
+    // depth === 1 → direct child of the schema, i.e. a global declaration
+    if (localName === 'element' && depth === 1 && schemaNs) {
+      const name = /\bname="([^"]*)"/.exec(raw)?.[1];
+      if (name) {
+        let set = map.get(name);
+        if (!set) {
+          set = new Set<string>();
+          map.set(name, set);
+        }
+        set.add(schemaNs);
+      }
+    }
+
+    if (!isSelfClosing) {
+      depth++;
+    }
+  }
+
+  return map;
+}

--- a/src/services/api-extractor.ts
+++ b/src/services/api-extractor.ts
@@ -18,6 +18,7 @@ import { redactAndWarnPolicySecrets } from './secret-redactor.js';
 import { logger } from '../lib/logger.js';
 import { buildResourceLabel } from '../lib/resource-uri.js';
 import { getNamePart } from '../lib/resource-path.js';
+import { normalizeWsdl } from '../lib/wsdl-normalizer.js';
 import { isWorkspaceScope, extractNameFromLink } from '../lib/workspace-link.js';
 
 /**
@@ -313,10 +314,17 @@ async function extractApiSpecification(
       return { extracted: false, errorCount: 0 };
     }
 
+    // APIM's WSDL export can emit wsdl:part references qualified with the wrong
+    // namespace prefix and multiple service ports, which its own importer then
+    // rejects. Normalize so the extracted artifact round-trips through publish.
+    const content = spec.format === 'wsdl'
+      ? normalizeWsdl(spec.content)
+      : spec.content;
+
     await store.writeContent(
       outputDir,
       apiDescriptor,
-      spec.content,
+      content,
       'specification',
       spec.format
     );

--- a/src/services/dry-run-reporter.ts
+++ b/src/services/dry-run-reporter.ts
@@ -12,6 +12,8 @@ import type { ApimServiceContext, ResourceDescriptor } from '../models/types.js'
 import type { PublishConfig } from '../models/config.js';
 import { getTopologicalOrder } from '../lib/dependency-graph.js';
 import { buildResourceLabel } from '../lib/resource-uri.js';
+import { getNamePart } from '../lib/resource-path.js';
+import { ResourceType } from '../models/resource-types.js';
 import { logger } from '../lib/logger.js';
 import { computeDeleteActions } from './delete-unmatched-service.js';
 
@@ -50,7 +52,14 @@ export async function generateDryRunReport(
   const descriptorsByType = groupDescriptorsByType(targetDescriptors);
 
   for (const resourceType of orderedTypes) {
-    const descriptors = descriptorsByType.get(resourceType) || [];
+    let descriptors = descriptorsByType.get(resourceType) || [];
+
+    // GatewayApi is discovered as an aggregate descriptor (nameParts = [gateway])
+    // from gateways/{gw}/apis.json. Expand to one descriptor per associated API
+    // so labels and counts mirror what publish would actually PUT.
+    if (resourceType === ResourceType.GatewayApi) {
+      descriptors = await expandGatewayApiDescriptors(store, config, descriptors);
+    }
 
     for (const descriptor of descriptors) {
       try {
@@ -176,6 +185,39 @@ function groupDescriptorsByType(
     map.set(descriptor.type, existing);
   }
   return map;
+}
+
+/**
+ * Expand aggregate GatewayApi descriptors (nameParts = [gateway]) into one
+ * descriptor per associated API by reading gateways/{gw}/apis.json.
+ * Descriptors that already carry both name parts pass through unchanged.
+ */
+async function expandGatewayApiDescriptors(
+  store: IArtifactStore,
+  config: PublishConfig,
+  descriptors: ResourceDescriptor[]
+): Promise<ResourceDescriptor[]> {
+  const expanded: ResourceDescriptor[] = [];
+  for (const descriptor of descriptors) {
+    if (descriptor.nameParts.length >= 2) {
+      expanded.push(descriptor);
+      continue;
+    }
+    const gatewayName = getNamePart(descriptor.nameParts, 0);
+    const entries = await store.readAssociation(
+      config.sourceDir,
+      { type: ResourceType.Gateway, nameParts: [gatewayName], workspace: descriptor.workspace },
+      'apis'
+    );
+    for (const entry of entries) {
+      expanded.push({
+        type: descriptor.type,
+        nameParts: [gatewayName, entry.name],
+        workspace: descriptor.workspace,
+      });
+    }
+  }
+  return expanded;
 }
 
 /**

--- a/tests/unit/lib/wsdl-normalizer.test.ts
+++ b/tests/unit/lib/wsdl-normalizer.test.ts
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+/**
+ * Unit tests for the WSDL normalizer
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeWsdl,
+  normalizeWsdlPartReferences,
+  normalizeWsdlServicePorts,
+} from '../../../src/lib/wsdl-normalizer.js';
+
+/** Reproduces APIM's broken WSDL export: parts reference tns instead of ns1. */
+function buildBrokenWsdl(): string {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:tns="https://example.org/service/v1"
+    targetNamespace="https://example.org/service/v1"
+    xmlns:ns1="https://example.org/messages/v1">
+    <wsdl:types>
+        <xs:schema targetNamespace="https://example.org/common/v1"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:complexType name="RequestContextType">
+                <xs:sequence>
+                    <xs:element name="correlationId" type="xs:string" />
+                </xs:sequence>
+            </xs:complexType>
+        </xs:schema>
+        <xs:schema targetNamespace="https://example.org/messages/v1"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:import namespace="https://example.org/common/v1" />
+            <xs:element name="GetCustomerRequest">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="customerId" type="xs:string" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="GetCustomerResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="status" type="xs:string" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:schema>
+    </wsdl:types>
+    <wsdl:message name="GetCustomer_InputMessage">
+        <wsdl:part name="parameters" element="tns:GetCustomerRequest" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomer_OutputMessage">
+        <wsdl:part name="parameters" element="tns:GetCustomerResponse" />
+    </wsdl:message>
+</wsdl:definitions>`;
+}
+
+describe('normalizeWsdlPartReferences', () => {
+  it('rewrites part references to the schema namespace that declares the element', () => {
+    const result = normalizeWsdlPartReferences(buildBrokenWsdl());
+
+    expect(result).toContain('element="ns1:GetCustomerRequest"');
+    expect(result).toContain('element="ns1:GetCustomerResponse"');
+    expect(result).not.toContain('element="tns:GetCustomerRequest"');
+  });
+
+  it('leaves already-correct references untouched', () => {
+    const correct = buildBrokenWsdl()
+      .replace('element="tns:GetCustomerRequest"', 'element="ns1:GetCustomerRequest"')
+      .replace('element="tns:GetCustomerResponse"', 'element="ns1:GetCustomerResponse"');
+
+    expect(normalizeWsdlPartReferences(correct)).toBe(correct);
+  });
+
+  it('adds a namespace declaration when no root prefix exists for the schema namespace', () => {
+    const noPrefix = buildBrokenWsdl().replace(
+      ' xmlns:ns1="https://example.org/messages/v1"',
+      ''
+    );
+
+    const result = normalizeWsdlPartReferences(noPrefix);
+
+    expect(result).toContain('xmlns:apiopsns0="https://example.org/messages/v1"');
+    expect(result).toContain('element="apiopsns0:GetCustomerRequest"');
+  });
+
+  it('does not rewrite references to elements declared in multiple schemas', () => {
+    const ambiguous = buildBrokenWsdl().replace(
+      '<xs:complexType name="RequestContextType">',
+      `<xs:element name="GetCustomerRequest">
+                <xs:complexType />
+            </xs:element>
+            <xs:complexType name="RequestContextType">`
+    );
+
+    const result = normalizeWsdlPartReferences(ambiguous);
+
+    expect(result).toContain('element="tns:GetCustomerRequest"');
+  });
+
+  it('does not rewrite references with prefixes not declared at the root', () => {
+    const undeclared = buildBrokenWsdl().replace(
+      'element="tns:GetCustomerRequest"',
+      'element="mystery:GetCustomerRequest"'
+    );
+
+    const result = normalizeWsdlPartReferences(undeclared);
+
+    expect(result).toContain('element="mystery:GetCustomerRequest"');
+  });
+
+  it('ignores nested local element declarations when resolving', () => {
+    // "customerId" is only a local element inside a complexType — a part
+    // referencing it must not be rewritten to the messages namespace.
+    const localRef = buildBrokenWsdl().replace(
+      'element="tns:GetCustomerRequest"',
+      'element="tns:customerId"'
+    );
+
+    const result = normalizeWsdlPartReferences(localRef);
+
+    expect(result).toContain('element="tns:customerId"');
+  });
+
+  it('returns non-WSDL content unchanged', () => {
+    const openapi = '{"openapi":"3.0.1","info":{"title":"x"}}';
+    expect(normalizeWsdlPartReferences(openapi)).toBe(openapi);
+  });
+});
+
+describe('normalizeWsdlServicePorts', () => {
+  const multiPortService = `<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+    <wsdl:service name="Svc">
+        <wsdl:port name="Svc-1" binding="tns:Svc">
+            <address location="https://gw-one.example.com/x" xmlns="http://schemas.xmlsoap.org/wsdl/soap/" />
+        </wsdl:port>
+        <wsdl:port name="Svc-2" binding="tns:Svc">
+            <address location="https://gw-two.example.com/x" xmlns="http://schemas.xmlsoap.org/wsdl/soap/" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>`;
+
+  it('keeps only the first port when a service has multiple ports', () => {
+    const result = normalizeWsdlServicePorts(multiPortService);
+
+    expect(result).toContain('name="Svc-1"');
+    expect(result).not.toContain('name="Svc-2"');
+    expect(result).toContain('gw-one.example.com');
+    expect(result).not.toContain('gw-two.example.com');
+  });
+
+  it('leaves a single-port service unchanged', () => {
+    const single = multiPortService.replace(
+      /\s*<wsdl:port name="Svc-2"[\s\S]*?<\/wsdl:port>/,
+      ''
+    );
+
+    expect(normalizeWsdlServicePorts(single)).toBe(single);
+  });
+});
+
+describe('normalizeWsdl', () => {
+  it('applies both part-reference and service-port normalizations', () => {
+    const broken = buildBrokenWsdl().replace(
+      '</wsdl:definitions>',
+      `<wsdl:service name="Svc">
+        <wsdl:port name="P1" binding="tns:B"><address location="https://a/x" /></wsdl:port>
+        <wsdl:port name="P2" binding="tns:B"><address location="https://b/x" /></wsdl:port>
+    </wsdl:service>\n</wsdl:definitions>`
+    );
+
+    const result = normalizeWsdl(broken);
+
+    expect(result).toContain('element="ns1:GetCustomerRequest"');
+    expect(result).not.toContain('name="P2"');
+  });
+});

--- a/tests/unit/services/dry-run-reporter.test.ts
+++ b/tests/unit/services/dry-run-reporter.test.ts
@@ -136,6 +136,36 @@ describe('dry-run-reporter', () => {
       );
     });
 
+    it('should expand aggregate GatewayApi descriptors into per-API actions', async () => {
+      const client = createMockClient();
+      const store = createMockStore();
+      store.readAssociation.mockResolvedValue([
+        { name: 'api-one' },
+        { name: 'api-two' },
+      ]);
+
+      // Discovery produces GatewayApi with only the gateway name (from apis.json)
+      const descriptors: ResourceDescriptor[] = [
+        { type: ResourceType.GatewayApi, nameParts: ['my-gateway'] },
+      ];
+
+      const report = await generateDryRunReport(store, client, testContext, testConfig, descriptors);
+
+      expect(store.readAssociation).toHaveBeenCalledWith(
+        '/source',
+        expect.objectContaining({ type: ResourceType.Gateway, nameParts: ['my-gateway'] }),
+        'apis'
+      );
+      expect(report.actions).toHaveLength(2);
+      expect(report.actions.map(a => a.name)).toEqual([
+        'my-gateway/api-one',
+        'my-gateway/api-two',
+      ]);
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('gateways/my-gateway/apis/api-one')
+      );
+    });
+
     it('should mark as PUT when resource exists (update)', async () => {
       const client = createMockClient(new Map([
         ['Tag:existing-tag', true],


### PR DESCRIPTION
## 🎯 Summary

This PR fixes three defects discovered while testing the full `extract → publish` round trip against **real APIM instances** (dev → prod), plus **4 high-severity npm audit vulnerabilities**. Each functional fix was reproduced and verified end-to-end on live services.

| # | Area | Symptom | Fix |
|---|------|---------|-----|
| 1 | `publish --dry-run` | Fatal crash on gateway→API associations | Expand aggregate `GatewayApi` descriptors |
| 2 | `extract` (SOAP/WSDL) | APIM re-import rejects its own WSDL export | New WSDL normalizer |
| 3 | `publish --delete-unmatched` | Intermittent `PreconditionFailed` on deletes | Retry with backoff |
| 4 | Dependencies | 4 high-severity vulnerabilities (`npm audit`) | `npm audit fix` |

## 🔍 Changes

### 1. Dry-run crashed on gateway→API associations
**File:** `src/services/dry-run-reporter.ts`

`publish --dry-run` failed fatally with `formatTemplatePath: nameParts[1] is undefined for template "gateways/{0}/apis/{1}"` whenever artifacts contained a gateway with associated APIs.

**Root cause:** artifact discovery produces an *aggregate* `GatewayApi` descriptor (`nameParts = [gateway]`) from `gateways/{gw}/apis.json`, while `buildResourceLabel` expects both name parts. The real publish path handles aggregates in `publishAssociation`; the dry-run reporter did not.

**Fix:** the reporter now expands aggregate descriptors into one action per associated API (reading `apis.json`), mirroring exactly what publish would PUT. APIs linked to multiple gateways produce one action per `(gateway, api)` pair.

### 2. WSDL export normalization
**Files:** `src/lib/wsdl-normalizer.ts` (new), `src/services/api-extractor.ts`

APIM regenerates WSDL on export and produces documents **its own importer rejects**, systematically breaking the GitOps round trip for SOAP APIs with multi-namespace schemas:

- ❌ `wsdl:part element="tns:X"` is qualified with the WSDL targetNamespace even when the element is declared in a different inline schema namespace → `ValidationError: Could not resolve type '{ns}X'`
- ❌ One `wsdl:port` emitted per configured proxy hostname → `ValidationError: Multiple service endpoints available, only one can be imported at a time`

**Fix:** `normalizeWsdl()` runs during extract for `wsdl`-format specifications only:

- `normalizeWsdlPartReferences` — rewrites a part reference **only** when it is unresolvable as-is *and* the element is declared in exactly one inline schema (depth-aware scan ignores nested local elements). Ambiguous or unknown references are left untouched. Adds a root xmlns declaration when no prefix exists for the target namespace.
- `normalizeWsdlServicePorts` — keeps the first `wsdl:port` per `wsdl:service`, drops the rest.

### 3. Retry on delete concurrency conflicts
**File:** `src/clients/apim-client.ts`

With `--delete-unmatched`, cascade deletes (subscriptions, product/gateway associations) run close together; APIM's async DELETE then intermittently fails with `[PreconditionFailed] Resource was modified since last retrieval`, leaving the target partially cleaned and requiring a manual re-run.

**Fix:** `deleteResource` retries up to 3 times with linear backoff (2s × attempt) on `[PreconditionFailed]` from async operation polling or a direct HTTP 412. All other errors propagate unchanged.

### 4. Dependency security fixes
**Files:** `package.json`, `package-lock.json`

Resolved **4 high-severity vulnerabilities** reported by `npm audit` via `npm audit fix` (no breaking version bumps; test suite passes unchanged).

## ✅ Testing

**Unit:** 1,163 tests pass (`npm test`), lint clean. New coverage:
- `tests/unit/lib/wsdl-normalizer.test.ts` — 10 tests: prefix rewrite, no-op on correct refs, generated xmlns declaration, ambiguous/undeclared/local-element skip paths, port dedup, combined normalization, non-WSDL passthrough
- `tests/unit/services/dry-run-reporter.test.ts` — regression test for aggregate `GatewayApi` expansion

**Live verification** (dev-APIM → prod-APIM):
- ✔️ dry-run over 84 resources incl. gateway associations — no crash, per-API labels
- ✔️ SOAP API (WSDL, 4 namespaces, 2 custom hostnames) — extract emits normalized WSDL, publish succeeds (previously failed with both ValidationErrors)
- ✔️ `--delete-unmatched` over 35 resources — previously 2 APIs failed with `PreconditionFailed`; retry resolves it

## 📝 Notes for reviewers

- The WSDL normalizer is regex/scanner-based (no new XML parser dependency), consistent with existing raw-XML policy handling; it is deliberately conservative — only provably broken references are rewritten.
- Dry-run cannot catch WSDL validation errors (no PUT bodies are sent) — pre-existing behavior, unchanged here.